### PR TITLE
Add push of manifest and config (for v2.2) references

### DIFF
--- a/docker/inspect.go
+++ b/docker/inspect.go
@@ -347,6 +347,7 @@ func makeImageInspect(img *image.Image, tag string, mfInfo manifestInfo, mediaTy
 		Os:              img.OS,
 		Layers:          digests,
 		Platform:        mfInfo.platform,
+		CanonicalJson:   mfInfo.jsonBytes,
 	}
 }
 

--- a/types/types.go
+++ b/types/types.go
@@ -21,4 +21,5 @@ type ImageInspect struct {
 	Os              string
 	Layers          []string
 	Platform        manifestlist.PlatformSpec
+	CanonicalJson   []byte
 }


### PR DESCRIPTION
To fully support cross-repository push we must ask for the blobs to be
mounted, but we must also push the manifests referenced into the target
namespace so that the manifest list push finds all its digest
references.  The config reference (in v2.2 spec) must also be added as a
blob mount request since it is referred to in the manifest we now push.

Signed-off-by: Phil Estes <estesp@gmail.com>