### PR TITLE
Show manifest list digest/info in inspect

### DIFF
--- a/docker/inspect.go
+++ b/docker/inspect.go
@@ -11,11 +11,11 @@ import (
 	"time"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/docker/distribution/manifest/manifestlist"
 	distreference "github.com/docker/distribution/reference"
 	"github.com/docker/distribution/registry/api/errcode"
 	"github.com/docker/distribution/registry/api/v2"
 	"github.com/docker/distribution/registry/client"
-
 	"github.com/docker/docker/api"
 	engineTypes "github.com/docker/docker/api/types"
 	registryTypes "github.com/docker/docker/api/types/registry"
@@ -327,6 +327,16 @@ func makeImageInspect(img *image.Image, tag string, mfInfo manifestInfo, mediaTy
 	if err := mfInfo.digest.Validate(); err == nil {
 		digest = mfInfo.digest.String()
 	}
+
+	// for manifest lists, we only want to display the basic info that this is
+	// a manifest list and its digest information:
+	if mediaType == manifestlist.MediaTypeManifestList {
+		return &types.ImageInspect{
+			MediaType: mediaType,
+			Digest:    digest,
+		}
+	}
+
 	var digests []string
 	for _, blobDigest := range mfInfo.blobDigests {
 		digests = append(digests, blobDigest.String())

--- a/docker/inspect_v2.go
+++ b/docker/inspect_v2.go
@@ -451,7 +451,7 @@ func schema2ManifestDigest(ref reference.Named, mfst distribution.Manifest) (dig
 }
 
 // pullManifestList handles "manifest lists" which point to various
-// platform-specifc manifests.
+// platform-specific manifests.
 func (mf *v2ManifestFetcher) pullManifestList(ctx context.Context, ref reference.Named, mfstList *manifestlist.DeserializedManifestList) ([]*image.Image, []manifestInfo, []string, error) {
 	var (
 		imageList = []*image.Image{}
@@ -463,6 +463,12 @@ func (mf *v2ManifestFetcher) pullManifestList(ctx context.Context, ref reference
 		return nil, nil, nil, err
 	}
 	logrus.Debugf("Pulling manifest list entries for ML digest %v", manifestListDigest)
+
+	// for displaying basic information on the "outer" manifest list entry, we will
+	// create the first entry in the returned arrays to hold the manifest list details:
+	mfInfos = append(mfInfos, manifestInfo{digest: manifestListDigest})
+	mediaType = append(mediaType, mfstList.MediaType)
+	imageList = append(imageList, &image.Image{})
 
 	for _, manifestDescriptor := range mfstList.Manifests {
 		manSvc, err := mf.repo.Manifests(ctx)

--- a/inspect.go
+++ b/inspect.go
@@ -49,8 +49,10 @@ var inspectCmd = cli.Command{
 			return
 		}
 		// more than one response--this is a manifest list
-		fmt.Printf("%s is a manifest list containing the following %d manifest references:\n", name, len(imgInspect))
-		for i, img := range imgInspect {
+		fmt.Printf("Name:   %s (Type: %s)\n", name, imgInspect[0].MediaType)
+		fmt.Printf("Digest: %s\n", imgInspect[0].Digest)
+		fmt.Printf(" * Contains %d manifest references:\n", len(imgInspect)-1)
+		for i, img := range imgInspect[1:] {
 			fmt.Printf("%d    Mfst Type: %s\n", i+1, img.MediaType)
 			fmt.Printf("%d       Digest: %s\n", i+1, img.Digest)
 			fmt.Printf("%d  Mfst Length: %d\n", i+1, img.Size)


### PR DESCRIPTION
Now outputs the manifest list digest as part of the
inspect output.

Signed-off-by: Phil Estes <estesp@gmail.com>