### PR TITLE
Update "version" string

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	version = "0.3.0"
+	version = "0.4.0-dev"
 	usage   = "inspect and push manifest list images to a registry"
 )
 

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ const (
 
 func main() {
 	app := cli.NewApp()
-	app.Name = "manifest"
+	app.Name = os.Args[0]
 	app.Version = version
 	app.Usage = usage
 	app.Flags = []cli.Flag{


### PR DESCRIPTION
I updated the `version` string to `0.4.0-dev`, but I'm happy to modify if you'd rather it be something else (but I figured that now that `0.4.0` is out, `0.3.0` probably isn't the right value to be in there anymore :smile:).