### PR TITLE
Automatically populate OS and architecture from source manifests (if unspecified)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,10 +82,6 @@ $ sudo make install
 $ make test-integration
 ```
 
-### TODO
-
- 1. Automatically populate OS and architecture from source manifests?
-
 ### License
 
 Apache License 2.0


### PR DESCRIPTION
Finally implemented that TODO item in the README (since looking at the code, it seemed relatively simple to plug in to the existing "inspect" logic at push-time).