### PR TITLE
Better handling of v2-only registry interaction

### DIFF
--- a/docker/inspect_v2.go
+++ b/docker/inspect_v2.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"runtime"
+	"strings"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/docker/distribution"
@@ -117,7 +118,11 @@ func (mf *v2ManifestFetcher) fetchWithRepository(ctx context.Context, ref refere
 	if err != nil {
 		// If this repository doesn't exist on V2, we should
 		// permit a fallback to V1.
-		return nil, allowV1Fallback(err)
+		if !strings.Contains(err.Error(), "unauthorized") {
+			// only error out if the the "list all tags" endpoint isn't blocked by the registry
+			// some registries may have a reason to not allow complete tag list queries
+			return nil, allowV1Fallback(err)
+		}
 	}
 
 	var (


### PR DESCRIPTION
Get rid of v1 endpoint ping (unecessary, as the entire support for
manifest lists requires a v2 endpoint anyway) and gracefully handle
potential registry limitations on getting all tag list. The IBM Bluemix
registry currently blocks the "list all tags" API endpoint, but it is
not required for inspect, as it just limits the output data in a small
way.

Signed-off-by: Phil Estes <estesp@gmail.com>