### PR TITLE
Allow extra tags to be provided for tagging the manifest list

### DIFF
--- a/types/types.go
+++ b/types/types.go
@@ -32,6 +32,7 @@ type ImageInspect struct {
 // command.
 type YAMLInput struct {
 	Image     string
+	Tags      []string
 	Manifests []ManifestEntry
 }
 


### PR DESCRIPTION
Provide the ability to add "tags: [ .. ]" to the input YAML with a list
of additional tags to push to the registry against the manifest list
object being pushed.

Signed-off-by: Phil Estes <estesp@gmail.com>

Fixes: #23 

And..seems to work :)
```
DEBU[0009] [extra tag "1.8"] push url: https://registry-1.docker.io/v2/estesp/bbimg/manifests/1.8
DEBU[0010] [extra tag "fred"] push url: https://registry-1.docker.io/v2/estesp/bbimg/manifests/fred
DEBU[0010] [extra tag "wilma"] push url: https://registry-1.docker.io/v2/estesp/bbimg/manifests/wilma
DEBU[0011] [extra tag "1.8-alpine"] push url: https://registry-1.docker.io/v2/estesp/bbimg/manifests/1.8-alpine
DEBU[0011] [extra tag "wilson-99"] push url: https://registry-1.docker.io/v2/estesp/bbimg/manifests/wilson-99
Digest: sha256:4b1a552465dd5a332c585fb1855d8db6592add9ada7d0583b0d3c92a20d74ca7
```