### PR TITLE
Add version detail; bump to 0.6.0-dev

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ INSTALLDIR=${PREFIX}/bin
 MANINSTALLDIR=${PREFIX}/share/man
 
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
+COMMIT_NO := $(shell git rev-parse HEAD 2> /dev/null || true)
+COMMIT := $(if $(shell git status --porcelain --untracked-files=no),"${COMMIT_NO}-dirty","${COMMIT_NO}")
 DOCKER_IMAGE := manifest-tool-dev$(if $(GIT_BRANCH),:$(GIT_BRANCH))
 # set env like gobuildtag?
 DOCKER_RUN := docker run --rm -i #$(DOCKER_ENVS)
@@ -21,10 +23,10 @@ all: build
 
 build:
 	$(DOCKER_RUN) -v $(shell pwd):/go/src/github.com/estesp/manifest-tool -w /go/src/github.com/estesp/manifest-tool golang:1.7 /bin/bash -c "\
-		go build -o manifest-tool github.com/estesp/manifest-tool"
+		go build -ldflags "-X main.gitCommit=${COMMIT}" -o manifest-tool github.com/estesp/manifest-tool"
 
 binary:
-	go build -o manifest-tool github.com/estesp/manifest-tool
+	go build -ldflags "-X main.gitCommit=${COMMIT}" -o manifest-tool github.com/estesp/manifest-tool
 
 build-container:
 	docker build ${DOCKER_BUILD_ARGS} -t "$(DOCKER_IMAGE)" .

--- a/main.go
+++ b/main.go
@@ -8,15 +8,18 @@ import (
 	"github.com/docker/docker/cli/config"
 )
 
+// will be filled in at compile time
+var gitCommit = ""
+
 const (
-	version = "0.6.0"
+	version = "0.6.0-dev"
 	usage   = "inspect and push manifest list images to a registry"
 )
 
 func main() {
 	app := cli.NewApp()
 	app.Name = os.Args[0]
-	app.Version = version
+	app.Version = version + " (commit: " + gitCommit + ")"
 	app.Usage = usage
 	app.Flags = []cli.Flag{
 		cli.BoolFlag{


### PR DESCRIPTION
Add commit info (+dirty flag) to version output. Bump to 0.6.0-dev to
differentiate from 0.6.0 released version.

Signed-off-by: Phil Estes <estesp@gmail.com>