### PR TITLE
Create static binaries by default on Linux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ build:
 		go build -ldflags "-X main.gitCommit=${COMMIT}" -o manifest-tool github.com/estesp/manifest-tool"
 
 binary:
-	go build -ldflags "-X main.gitCommit=${COMMIT}" -o manifest-tool github.com/estesp/manifest-tool
+	go build -ldflags "-w -extldflags -static -X main.gitCommit=${COMMIT}" -o manifest-tool github.com/estesp/manifest-tool
 
 build-container:
 	docker build ${DOCKER_BUILD_ARGS} -t "$(DOCKER_IMAGE)" .

--- a/hack/Dockerfile.linux-amd64
+++ b/hack/Dockerfile.linux-amd64
@@ -1,0 +1,7 @@
+FROM alpine:3.6
+
+RUN apk update && apk add ca-certificates \
+	&& update-ca-certificates
+
+COPY manifest-tool-linux-amd64 /manifest-tool
+ENTRYPOINT [ "/manifest-tool" ]

--- a/hack/Dockerfile.linux-arm
+++ b/hack/Dockerfile.linux-arm
@@ -1,0 +1,7 @@
+FROM arm32v6/alpine:3.6
+
+RUN apk update && apk add ca-certificates \
+	&& update-ca-certificates
+
+COPY manifest-tool-linux-arm /manifest-tool
+ENTRYPOINT [ "/manifest-tool" ]

--- a/hack/Dockerfile.linux-arm64
+++ b/hack/Dockerfile.linux-arm64
@@ -1,0 +1,7 @@
+FROM arm64v8/alpine:3.6
+
+RUN apk update && apk add ca-certificates \
+	&& update-ca-certificates
+
+COPY manifest-tool-linux-arm64 /manifest-tool
+ENTRYPOINT [ "/manifest-tool" ]

--- a/hack/Dockerfile.linux-ppc64le
+++ b/hack/Dockerfile.linux-ppc64le
@@ -1,0 +1,7 @@
+FROM ppc64le/alpine:3.6
+
+RUN apk update && apk add ca-certificates \
+	&& update-ca-certificates
+
+COPY manifest-tool-linux-ppc64le /manifest-tool
+ENTRYPOINT [ "/manifest-tool" ]

--- a/hack/Dockerfile.linux-s390x
+++ b/hack/Dockerfile.linux-s390x
@@ -1,0 +1,7 @@
+FROM s390x/alpine:3.6
+
+RUN apk update && apk add ca-certificates \
+	&& update-ca-certificates
+
+COPY manifest-tool-linux-s390x /manifest-tool
+ENTRYPOINT [ "/manifest-tool" ]

--- a/hack/cross.sh
+++ b/hack/cross.sh
@@ -2,6 +2,14 @@
 
 BINARY="manifest-tool"
 
+GIT_BRANCH=`git rev-parse --abbrev-ref HEAD 2>/dev/null`
+COMMIT=`git rev-parse HEAD 2>/dev/null`
+[[ -n `git status --porcelain --untracked-files=no` ]] && {
+  COMMIT="${COMMIT}-dirty"; }
+
+LDFLAGS="-w -extldflags -static -X main.gitCommit=${COMMIT}"
+LDFLAGS_OTHER="-X main.gitCommit=${COMMIT}"
+
 # List of platforms we build binaries for at this time:
 PLATFORMS="darwin/amd64 windows/amd64 linux/amd64" # OSX, Windows, Linux x86_64
 PLATFORMS="$PLATFORMS linux/ppc64le linux/s390x"   # IBM POWER and z Systems
@@ -10,9 +18,11 @@ PLATFORMS="$PLATFORMS linux/arm linux/arm64"       # ARM; 32bit and 64bit
 for PLATFORM in $PLATFORMS; do
   GOOS=${PLATFORM%/*}
   GOARCH=${PLATFORM#*/}
+  _LDFLAGS=${LDFLAGS}
   BIN_FILENAME="${BINARY}-${GOOS}-${GOARCH}"
   if [[ "${GOOS}" == "windows" ]]; then BIN_FILENAME="${BIN_FILENAME}.exe"; fi
-  CMD="GOOS=${GOOS} GOARCH=${GOARCH} go build -o ${BIN_FILENAME} ."
+  if [[ "${GOOS}" != "linux" ]]; then _LDFLAGS="${LDFLAGS_OTHER}"; fi
+  CMD="GOOS=${GOOS} GOARCH=${GOARCH} go build -ldflags \"${_LDFLAGS}\" -o ${BIN_FILENAME} ."
   echo "${CMD}"
   eval $CMD || FAILURES="${FAILURES} ${PLATFORM}"
 done


### PR DESCRIPTION
Create static binaries; also include commit information in the `make
cross` target. Add Dockerfile instances for all Linux architectures in
preparation of having an easy to use multi-platform image to test
`manifest-tool` on any architecture.

Signed-off-by: Phil Estes <estesp@gmail.com>