### PR TITLE
Fix static and non-static targets in Makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,7 @@ manifests:
 
 ### Building
 
-The releases of `manifest-tool` are built using the latest Go version; currently 1.8.x. If you wish to build `manifest-tool` using a version prior to 1.6, you will need to export the variable `GO15VENDOREXPERIMENT` into your build environment.
+The releases of `manifest-tool` are built using the latest Go version; currently 1.9.1.
 
 To build `manifest-tool`, clone this repository into your `$GOPATH`:
 
@@ -219,6 +219,8 @@ $ cd github.com/estesp
 $ git clone https://github.com/estesp/manifest-tool
 $ cd manifest-tool && make binary
 ```
+
+If you do not have a local Golang environment, you can use the `make build` target to build `manifest-tool` in a Golang 1.9.1-based container environment. This will require that you have Docker installed. The `make static` target will build a statically-linked binary, and `make cross` is used to build all supported CPU architectures, creating static binaries for each platform.
 
 Note that signed binary releases are available on the project's [GitHub releases page](https://github.com/estesp/manifest-tool/releases) for several CPU architectures for Linux as well as OSX/macOS.
 

--- a/hack/cross.sh
+++ b/hack/cross.sh
@@ -22,7 +22,7 @@ for PLATFORM in $PLATFORMS; do
   BIN_FILENAME="${BINARY}-${GOOS}-${GOARCH}"
   if [[ "${GOOS}" == "windows" ]]; then BIN_FILENAME="${BIN_FILENAME}.exe"; fi
   if [[ "${GOOS}" != "linux" ]]; then _LDFLAGS="${LDFLAGS_OTHER}"; fi
-  CMD="GOOS=${GOOS} GOARCH=${GOARCH} go build -ldflags \"${_LDFLAGS}\" -o ${BIN_FILENAME} ."
+  CMD="CGO_ENABLED=0 GO_EXTLINK_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} go build -ldflags \"${_LDFLAGS}\" -o ${BIN_FILENAME} -tags netgo -installsuffix netgo ."
   echo "${CMD}"
   eval $CMD || FAILURES="${FAILURES} ${PLATFORM}"
 done


### PR DESCRIPTION
Modify `binary` target to match `build` target to build a standard,
dynamically-linked executable; one via Dockerfile, one via local system.

Add `static` target to properly build a static binary, and correct
`hack/cross.sh` script to also build proper static binaries.

Signed-off-by: Phil Estes <estesp@gmail.com>