### PR TITLE
Update "hack/cross.sh" to set "GOARM" appropriately (and build for more ARM variants)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.7
+FROM golang:1.9
 
 ENV GO_TOOLS_COMMIT 823804e1ae08dbb14eb807afc7db9993bc9e3cc3
 # Grab Go's cover tool for dead-simple code coverage testing

--- a/hack/cross.sh
+++ b/hack/cross.sh
@@ -1,35 +1,61 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -Eeuo pipefail
 
-BINARY="manifest-tool"
+BINARY='manifest-tool'
 
-GIT_BRANCH=`git rev-parse --abbrev-ref HEAD 2>/dev/null`
-COMMIT=`git rev-parse HEAD 2>/dev/null`
-[[ -n `git status --porcelain --untracked-files=no` ]] && {
-  COMMIT="${COMMIT}-dirty"; }
+COMMIT="$(git rev-parse HEAD 2>/dev/null)"
+if [ -n "$(git status --porcelain --untracked-files=no)" ]; then
+  COMMIT="${COMMIT}-dirty"
+fi
 
 LDFLAGS="-w -extldflags -static -X main.gitCommit=${COMMIT}"
 LDFLAGS_OTHER="-X main.gitCommit=${COMMIT}"
 
 # List of platforms we build binaries for at this time:
-PLATFORMS="darwin/amd64 windows/amd64 linux/amd64" # OSX, Windows, Linux x86_64
-PLATFORMS="$PLATFORMS linux/ppc64le linux/s390x"   # IBM POWER and z Systems
-PLATFORMS="$PLATFORMS linux/arm linux/arm64"       # ARM; 32bit and 64bit
+PLATFORMS=(
+  # format: GOOS/GOARCH[/GOARM]
 
-for PLATFORM in $PLATFORMS; do
-  GOOS=${PLATFORM%/*}
-  GOARCH=${PLATFORM#*/}
-  _LDFLAGS=${LDFLAGS}
+  # OSX, Windows, Linux x86_64/i386
+  darwin/amd64 windows/amd64 linux/amd64 linux/386
+
+  # IBM POWER and z Systems
+  linux/ppc64le linux/s390x
+
+  # ARM; 32bit and 64bit
+  linux/arm/5 linux/arm/6 linux/arm/7 linux/arm64
+)
+
+FAILURES=()
+
+for PLATFORM in "${PLATFORMS[@]}"; do
+  GOOS="${PLATFORM%%/*}"
+  GOARM="${PLATFORM#$GOOS/}"
+  GOARCH="${GOARM%%/*}"
+  GOARM="${GOARM#$GOARCH/}"
+
   BIN_FILENAME="${BINARY}-${GOOS}-${GOARCH}"
-  if [[ "${GOOS}" == "windows" ]]; then BIN_FILENAME="${BIN_FILENAME}.exe"; fi
-  if [[ "${GOOS}" != "linux" ]]; then _LDFLAGS="${LDFLAGS_OTHER}"; fi
-  CMD="CGO_ENABLED=0 GO_EXTLINK_ENABLED=0 GOOS=${GOOS} GOARCH=${GOARCH} go build -ldflags \"${_LDFLAGS}\" -o ${BIN_FILENAME} -tags netgo -installsuffix netgo ."
+  ARCH_ENV="GOOS=${GOOS} GOARCH=${GOARCH}"
+  if [ "${GOARCH}" = 'arm' ]; then
+    [ -n "${GOARM}" ] || echo >&2 "WARNING: missing GOARM value for $PLATFORM in ${BASH_SOURCE[0]}"
+    # "manifest-tool-linux-armv7", etc
+    BIN_FILENAME="${BIN_FILENAME}v${GOARM}"
+    ARCH_ENV="${ARCH_ENV} GOARM=${GOARM}"
+  fi
+  if [ "${GOOS}" = 'windows' ]; then
+    BIN_FILENAME="${BIN_FILENAME}.exe"
+  fi
+
+  [ "${GOOS}" = 'linux' ] && _LDFLAGS="${LDFLAGS}" || _LDFLAGS="${LDFLAGS_OTHER}"
+
+  CMD="${ARCH_ENV} CGO_ENABLED=0 GO_EXTLINK_ENABLED=0 go build -ldflags \"${_LDFLAGS}\" -o ${BIN_FILENAME} -tags netgo -installsuffix netgo ."
   echo "${CMD}"
-  eval $CMD || FAILURES="${FAILURES} ${PLATFORM}"
+  eval "${CMD}" || FAILURES=( "${FAILURES[@]}" "${PLATFORM}" )
 done
 
 # eval errors
-if [[ "${FAILURES}" != "" ]]; then
-  echo ""
-  echo "${BINARY} build failed on: ${FAILURES}"
+if [ "${#FAILURES[@]}" -gt 0 ]; then
+  echo >&2
+  echo >&2 "ERROR: ${BINARY} build failed on: ${FAILURES[*]}"
+  echo >&2
   exit 1
 fi


### PR DESCRIPTION
This also updates `Dockerfile` to Go 1.9 (as in https://github.com/estesp/manifest-tool/pull/48) to avoid the privilege of having to deal with https://github.com/golang/go/issues/9737#issuecomment-276817652.

Sample output:

```console
$ make shell
docker build  -t "estesp/manifest-tool-dev:goarm" .
Sending build context to Docker daemon  103.2MB
Step 1/8 : FROM golang:1.9
 ---> bba10fd6d576
Step 2/8 : ENV GO_TOOLS_COMMIT 823804e1ae08dbb14eb807afc7db9993bc9e3cc3
 ---> Using cache
 ---> bed437ce0cee
Step 3/8 : RUN git clone https://github.com/golang/tools.git /go/src/golang.org/x/tools 	&& (cd /go/src/golang.org/x/tools && git checkout -q $GO_TOOLS_COMMIT) 	&& go install -v golang.org/x/tools/cmd/cover 	&& go install -v golang.org/x/tools/cmd/vet
 ---> Using cache
 ---> 0782f10f6d01
Step 4/8 : ENV GO_LINT_COMMIT 32a87160691b3c96046c0c678fe57c5bef761456
 ---> Using cache
 ---> e96bb8b4e173
Step 5/8 : RUN git clone https://github.com/golang/lint.git /go/src/github.com/golang/lint 	&& (cd /go/src/github.com/golang/lint && git checkout -q $GO_LINT_COMMIT) 	&& go install -v github.com/golang/lint/golint
 ---> Using cache
 ---> 03a5e4dd527a
Step 6/8 : ENV REGISTRY_COMMIT 47a064d4195a9b56133891bbb13620c3ac83a827
 ---> Using cache
 ---> c1337914b0be
Step 7/8 : RUN set -x 	&& export GOPATH="$(mktemp -d)" 	&& git clone https://github.com/docker/distribution.git "$GOPATH/src/github.com/docker/distribution" 	&& (cd "$GOPATH/src/github.com/docker/distribution" && git checkout -q "$REGISTRY_COMMIT") 	&& GOPATH="$GOPATH/src/github.com/docker/distribution/Godeps/_workspace:$GOPATH" 		go build -o /usr/local/bin/registry github.com/docker/distribution/cmd/registry 	&& rm -rf "$GOPATH"
 ---> Using cache
 ---> 82840b0eb804
Step 8/8 : WORKDIR /go/src/github.com/estesp/manifest-tool
 ---> Using cache
 ---> 5d258edb8f7d
Successfully built 5d258edb8f7d
Successfully tagged estesp/manifest-tool-dev:goarm
docker run --rm -i  -t -v /home/tianon/docker/manifest-tool:/go/src/github.com/estesp/manifest-tool -w /go/src/github.com/estesp/manifest-tool "estesp/manifest-tool-dev:goarm" bash
root@b3ef69cc62f5:/go/src/github.com/estesp/manifest-tool# make cross
hack/cross.sh
GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 GO_EXTLINK_ENABLED=0 go build -ldflags "-X main.gitCommit=9c28a6ee32f1e4fa801d5e5ae82bb84ab2ffac38-dirty" -o manifest-tool-darwin-amd64 -tags netgo -installsuffix netgo .
GOOS=windows GOARCH=amd64 CGO_ENABLED=0 GO_EXTLINK_ENABLED=0 go build -ldflags "-X main.gitCommit=9c28a6ee32f1e4fa801d5e5ae82bb84ab2ffac38-dirty" -o manifest-tool-windows-amd64.exe -tags netgo -installsuffix netgo .
GOOS=linux GOARCH=amd64 CGO_ENABLED=0 GO_EXTLINK_ENABLED=0 go build -ldflags "-w -extldflags -static -X main.gitCommit=9c28a6ee32f1e4fa801d5e5ae82bb84ab2ffac38-dirty" -o manifest-tool-linux-amd64 -tags netgo -installsuffix netgo .
GOOS=linux GOARCH=386 CGO_ENABLED=0 GO_EXTLINK_ENABLED=0 go build -ldflags "-w -extldflags -static -X main.gitCommit=9c28a6ee32f1e4fa801d5e5ae82bb84ab2ffac38-dirty" -o manifest-tool-linux-386 -tags netgo -installsuffix netgo .
GOOS=linux GOARCH=ppc64le CGO_ENABLED=0 GO_EXTLINK_ENABLED=0 go build -ldflags "-w -extldflags -static -X main.gitCommit=9c28a6ee32f1e4fa801d5e5ae82bb84ab2ffac38-dirty" -o manifest-tool-linux-ppc64le -tags netgo -installsuffix netgo .
GOOS=linux GOARCH=s390x CGO_ENABLED=0 GO_EXTLINK_ENABLED=0 go build -ldflags "-w -extldflags -static -X main.gitCommit=9c28a6ee32f1e4fa801d5e5ae82bb84ab2ffac38-dirty" -o manifest-tool-linux-s390x -tags netgo -installsuffix netgo .
GOOS=linux GOARCH=arm GOARM=5 CGO_ENABLED=0 GO_EXTLINK_ENABLED=0 go build -ldflags "-w -extldflags -static -X main.gitCommit=9c28a6ee32f1e4fa801d5e5ae82bb84ab2ffac38-dirty" -o manifest-tool-linux-armv5 -tags netgo -installsuffix netgo .
GOOS=linux GOARCH=arm GOARM=6 CGO_ENABLED=0 GO_EXTLINK_ENABLED=0 go build -ldflags "-w -extldflags -static -X main.gitCommit=9c28a6ee32f1e4fa801d5e5ae82bb84ab2ffac38-dirty" -o manifest-tool-linux-armv6 -tags netgo -installsuffix netgo .
GOOS=linux GOARCH=arm GOARM=7 CGO_ENABLED=0 GO_EXTLINK_ENABLED=0 go build -ldflags "-w -extldflags -static -X main.gitCommit=9c28a6ee32f1e4fa801d5e5ae82bb84ab2ffac38-dirty" -o manifest-tool-linux-armv7 -tags netgo -installsuffix netgo .
GOOS=linux GOARCH=arm64 CGO_ENABLED=0 GO_EXTLINK_ENABLED=0 go build -ldflags "-w -extldflags -static -X main.gitCommit=9c28a6ee32f1e4fa801d5e5ae82bb84ab2ffac38-dirty" -o manifest-tool-linux-arm64 -tags netgo -installsuffix netgo .
root@b3ef69cc62f5:/go/src/github.com/estesp/manifest-tool# exit
$ file manifest-tool-*
manifest-tool-darwin-amd64:      Mach-O 64-bit x86_64 executable, flags:<NOUNDEFS>
manifest-tool-linux-386:         ELF 32-bit LSB executable, Intel 80386, version 1 (SYSV), statically linked, not stripped
manifest-tool-linux-amd64:       ELF 64-bit LSB executable, x86-64, version 1 (SYSV), statically linked, not stripped
manifest-tool-linux-arm64:       ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, not stripped
manifest-tool-linux-armv5:       ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked, not stripped
manifest-tool-linux-armv6:       ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked, not stripped
manifest-tool-linux-armv7:       ELF 32-bit LSB executable, ARM, EABI5 version 1 (SYSV), statically linked, not stripped
manifest-tool-linux-ppc64le:     ELF 64-bit LSB executable, 64-bit PowerPC or cisco 7500, version 1 (SYSV), statically linked, not stripped
manifest-tool-linux-s390x:       ELF 64-bit MSB executable, IBM S/390, version 1 (SYSV), statically linked, not stripped
manifest-tool-windows-amd64.exe: PE32+ executable (console) x86-64 (stripped to external PDB), for MS Windows
```