### PR TITLE
Fix use of * for permissions request on token auth

### DIFF
--- a/docker/createml.go
+++ b/docker/createml.go
@@ -283,7 +283,7 @@ func getHTTPClient(a *types.AuthInfo, repoInfo *registry.RepositoryInfo, endpoin
 		modifiers = append(modifiers, auth.NewAuthorizer(challengeManager, passThruTokenHandler))
 	} else {
 		creds := dumbCredentialStore{auth: &authConfig}
-		tokenHandler := auth.NewTokenHandler(authTransport, creds, repoName, "*")
+		tokenHandler := auth.NewTokenHandler(authTransport, creds, repoName, "push", "pull")
 		basicHandler := auth.NewBasicHandler(creds)
 		modifiers = append(modifiers, auth.NewAuthorizer(challengeManager, tokenHandler, basicHandler))
 	}


### PR DESCRIPTION
GitLab and potentially other registries may not handle "*" properly as
the requested permissions; explicitly ask for "push" and "pull"

Signed-off-by: Phil Estes <estesp@gmail.com>

Fix brought in from docker/cli#1024 thanks @clnperez :)
Fixes: #53 