### PR TITLE
allow to specify variant in args

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,8 +194,8 @@ $ ./manifest-tool push from-args \
 On the command line you specify the platform os/arch pairs, a template for finding the source images for each input platform pair, and a target image name.
 
 Specifically:
- - `--platforms` specifies which platforms you want to push for in the form OS/ARCH,OS/ARCH,...
- - `--template` specifies the image repo:tag source for inputs by replacing the placeholders `OS` and `ARCH` with the inputs from `--platforms`.
+ - `--platforms` specifies which platforms you want to push for in the form OS/ARCH[/VARIANT],OS/ARCH[/VARIANT],...
+ - `--template` specifies the image repo:tag source for inputs by replacing the placeholders `OS`, `ARCH` and `VARIANT` with the inputs from `--platforms`.
  - `--target` specifies the target image repo:tag that will be the manifest list entry in the registry.
 
 ##### Functional Changelog for Push/Create

--- a/push.go
+++ b/push.go
@@ -93,15 +93,20 @@ var pushCmd = cli.Command{
 
 				for _, platform := range platformList {
 					osArchArr := strings.Split(platform, "/")
-					if len(osArchArr) != 2 {
-						logrus.Fatal("The --platforms argument must be a string slice where one value is of the form 'os/arch'")
+					if len(osArchArr) < 2 || len(osArchArr) > 3 {
+						logrus.Fatal("The --platforms argument must be a string slice where one value is of the form 'os/arch/[variant]'")
 					}
 					os, arch := osArchArr[0], osArchArr[1]
+					variant := ""
+					if len(osArchArr) == 3 {
+						variant = osArchArr[2]
+					}
 					srcImages = append(srcImages, types.ManifestEntry{
-						Image: strings.Replace(strings.Replace(templ, "ARCH", arch, 1), "OS", os, 1),
+						Image: strings.Replace(strings.Replace(strings.Replace(templ, "ARCH", arch, 1), "OS", os, 1), "VARIANT", variant, 1),
 						Platform: manifestlist.PlatformSpec{
 							OS:           os,
 							Architecture: arch,
+							Variant:      variant,
 						},
 					})
 				}


### PR DESCRIPTION
Besides OS and ARCH, also allow to specify VARIANT in command
line arguments.

Signed-off-by: Stefan Agner <stefan@agner.ch>