### PR TITLE
Add support for http/insecure registries

### DIFF
--- a/inspect.go
+++ b/inspect.go
@@ -23,7 +23,7 @@ var inspectCmd = cli.Command{
 
 		name := c.Args().First()
 		a := getAuthInfo(c)
-		imgInspect, _, err := docker.GetImageData(a, name)
+		imgInspect, _, err := docker.GetImageData(a, name, c.GlobalBool("insecure"))
 		if err != nil {
 			logrus.Fatal(err)
 		}

--- a/main.go
+++ b/main.go
@@ -26,6 +26,10 @@ func main() {
 			Name:  "debug",
 			Usage: "enable debug output",
 		},
+		cli.BoolFlag{
+			Name:  "insecure",
+			Usage: "allow http/insecure registry communication",
+		},
 		cli.StringFlag{
 			Name:  "username",
 			Value: "",

--- a/push.go
+++ b/push.go
@@ -48,7 +48,7 @@ var pushCmd = cli.Command{
 					logrus.Fatalf(fmt.Sprintf("Can't unmarshal YAML file %q: %v", filePath, err))
 				}
 
-				digest, l, err := docker.PutManifestList(a, yamlInput, ignoreMissing)
+				digest, l, err := docker.PutManifestList(a, yamlInput, ignoreMissing, c.GlobalBool("insecure"))
 				if err != nil {
 					logrus.Fatal(err)
 				}
@@ -111,7 +111,7 @@ var pushCmd = cli.Command{
 					Manifests: srcImages,
 				}
 
-				digest, l, err := docker.PutManifestList(a, yamlInput, ignoreMissing)
+				digest, l, err := docker.PutManifestList(a, yamlInput, ignoreMissing, c.GlobalBool("insecure"))
 				if err != nil {
 					logrus.Fatal(err)
 				}


### PR DESCRIPTION
Add necessary support as well as an `--insecure` flag for manifest-tool
to be able to interact with non-TLS registry endpoints (or self-signed
certs untrusted by the client-side)

Fixes: #14 
Signed-off-by: Phil Estes <estesp@gmail.com>