### PR TITLE
adds support for variants in the from-args feature

### DIFF
--- a/docker/createml.go
+++ b/docker/createml.go
@@ -96,6 +96,7 @@ func PutManifestList(a *types.AuthInfo, yamlInput types.YAMLInput, ignoreMissing
 				img.Platform.Architecture = imgMfst.Architecture
 			}
 		}
+
 		// if the origin image has OSFeature and/or OSVersion information, and
 		// these values were not specified in the creation YAML, then
 		// retain the origin values in the Platform definition for the manifest list:
@@ -106,9 +107,13 @@ func PutManifestList(a *types.AuthInfo, yamlInput types.YAMLInput, ignoreMissing
 			img.Platform.OSFeatures = imgMfst.OSFeatures
 		}
 
+		if imgMfst.Variant != "" {
+			img.Platform.Variant = imgMfst.Variant
+		}
+
 		// validate os/arch input
-		if !isValidOSArch(img.Platform.OS, img.Platform.Architecture) {
-			return "", 0, fmt.Errorf("Manifest entry for image %s has unsupported os/arch combination: %s/%s", img.Image, img.Platform.OS, img.Platform.Architecture)
+		if !isValidOSArch(img.Platform.OS, img.Platform.Architecture, img.Platform.Variant) {
+			return "", 0, fmt.Errorf("Manifest entry for image %s has unsupported os/arch or os/arch/variant combination: %s/%s/%s", img.Image, img.Platform.OS, img.Platform.Architecture, img.Platform.Variant)
 		}
 
 		manifest := manifestlist.ManifestDescriptor{

--- a/docker/createml.go
+++ b/docker/createml.go
@@ -107,10 +107,6 @@ func PutManifestList(a *types.AuthInfo, yamlInput types.YAMLInput, ignoreMissing
 			img.Platform.OSFeatures = imgMfst.OSFeatures
 		}
 
-		if imgMfst.Variant != "" {
-			img.Platform.Variant = imgMfst.Variant
-		}
-
 		// validate os/arch input
 		if !isValidOSArch(img.Platform.OS, img.Platform.Architecture, img.Platform.Variant) {
 			return "", 0, fmt.Errorf("Manifest entry for image %s has unsupported os/arch or os/arch/variant combination: %s/%s/%s", img.Image, img.Platform.OS, img.Platform.Architecture, img.Platform.Variant)

--- a/docker/util.go
+++ b/docker/util.go
@@ -18,7 +18,10 @@ var validOSArch = map[string]bool{
 	"linux/386":       true,
 	"linux/amd64":     true,
 	"linux/arm":       true,
+	"linux/arm/v5":    true,
+	"linux/arm/v7":    true,
 	"linux/arm64":     true,
+	"linux/arm64/v8":  true,
 	"linux/ppc64":     true,
 	"linux/ppc64le":   true,
 	"linux/mips64":    true,
@@ -38,8 +41,13 @@ var validOSArch = map[string]bool{
 	"windows/arm":     true,
 }
 
-func isValidOSArch(os string, arch string) bool {
+func isValidOSArch(os string, arch string, variant string) bool {
 	osarch := fmt.Sprintf("%s/%s", os, arch)
+
+	if variant != "" {
+		osarch = fmt.Sprintf("%s/%s/%s", os, arch, variant)
+	}
+
 	_, ok := validOSArch[osarch]
 	return ok
 }

--- a/docker/util.go
+++ b/docker/util.go
@@ -19,6 +19,7 @@ var validOSArch = map[string]bool{
 	"linux/amd64":     true,
 	"linux/arm":       true,
 	"linux/arm/v5":    true,
+	"linux/arm/v6":    true,
 	"linux/arm/v7":    true,
 	"linux/arm64":     true,
 	"linux/arm64/v8":  true,

--- a/docker/util_test.go
+++ b/docker/util_test.go
@@ -4,59 +4,62 @@ import "testing"
 
 func TestValidOSArch(t *testing.T) {
 	var crctosarch = []struct {
-		arch, os string
+		arch, os, variant string
 	}{
-		{"darwin", "386"},
-		{"linux", "arm"},
-		{"windows", "amd64"},
-		{"darwin", "386"},
-		{"darwin", "amd64"},
-		{"darwin", "arm"},
-		{"darwin", "arm64"},
-		{"dragonfly", "amd64"},
-		{"freebsd", "386"},
-		{"freebsd", "amd64"},
-		{"freebsd", "arm"},
-		{"linux", "386"},
-		{"linux", "amd64"},
-		{"linux", "arm"},
-		{"linux", "arm64"},
-		{"linux", "ppc64"},
-		{"linux", "ppc64le"},
-		{"linux", "mips64"},
-		{"linux", "mips64le"},
-		{"linux", "s390x"},
-		{"netbsd", "386"},
-		{"netbsd", "amd64"},
-		{"netbsd", "arm"},
-		{"openbsd", "386"},
-		{"openbsd", "amd64"},
-		{"openbsd", "arm"},
-		{"plan9", "386"},
-		{"plan9", "amd64"},
-		{"solaris", "amd64"},
-		{"windows", "386"},
-		{"windows", "amd64"},
+		{arch: "darwin", os: "386"},
+		{arch: "linux", os: "arm"},
+		{arch: "windows", os: "amd64"},
+		{arch: "darwin", os: "386"},
+		{arch: "darwin", os: "amd64"},
+		{arch: "darwin", os: "arm"},
+		{arch: "darwin", os: "arm64"},
+		{arch: "dragonfly", os: "amd64"},
+		{arch: "freebsd", os: "386"},
+		{arch: "freebsd", os: "amd64"},
+		{arch: "freebsd", os: "arm"},
+		{arch: "linux", os: "386"},
+		{arch: "linux", os: "amd64"},
+		{arch: "linux", os: "arm"},
+		{arch: "linux", os: "arm", variant: "v5"},
+		{arch: "linux", os: "arm", variant: "v7"},
+		{arch: "linux", os: "arm64"},
+		{arch: "linux", os: "arm64", variant: "v8"},
+		{arch: "linux", os: "ppc64"},
+		{arch: "linux", os: "ppc64le"},
+		{arch: "linux", os: "mips64"},
+		{arch: "linux", os: "mips64le"},
+		{arch: "linux", os: "s390x"},
+		{arch: "netbsd", os: "386"},
+		{arch: "netbsd", os: "amd64"},
+		{arch: "netbsd", os: "arm"},
+		{arch: "openbsd", os: "386"},
+		{arch: "openbsd", os: "amd64"},
+		{arch: "openbsd", os: "arm"},
+		{arch: "plan9", os: "386"},
+		{arch: "plan9", os: "amd64"},
+		{arch: "solaris", os: "amd64"},
+		{arch: "windows", os: "386"},
+		{arch: "windows", os: "amd64"},
 	}
 	var wrongosarch = []struct {
-		arch, os string
+		arch, os, variant string
 	}{
-		{"abc", "123"},
-		{"xyz", "etc"},
-		{"", ""},
+		{arch: "abc", os: "123"},
+		{arch: "xyz", os: "etc"},
+		{arch: "", os: ""},
 	}
 
 	for _, i := range crctosarch {
-		res := isValidOSArch(i.arch, i.os)
+		res := isValidOSArch(i.arch, i.os, i.variant)
 		if res != true {
-			t.Errorf("%s/%s is an invalid os/arch combination", i.arch, i.os)
+			t.Errorf("%s/%s/%s is an invalid os/arch or os/arch/variant combination", i.arch, i.os, i.variant)
 		}
 	}
 
 	for _, j := range wrongosarch {
-		res := isValidOSArch(j.arch, j.os)
+		res := isValidOSArch(j.arch, j.os, j.variant)
 		if res == true {
-			t.Errorf("%s/%s is an invalid os/arch combination", j.arch, j.os)
+			t.Errorf("%s/%s/%s is an invalid os/arch or os/arch/variant combination", j.arch, j.os, j.variant)
 		}
 	}
 

--- a/docker/util_test.go
+++ b/docker/util_test.go
@@ -21,6 +21,7 @@ func TestValidOSArch(t *testing.T) {
 		{arch: "linux", os: "amd64"},
 		{arch: "linux", os: "arm"},
 		{arch: "linux", os: "arm", variant: "v5"},
+		{arch: "linux", os: "arm", variant: "v6"},
 		{arch: "linux", os: "arm", variant: "v7"},
 		{arch: "linux", os: "arm64"},
 		{arch: "linux", os: "arm64", variant: "v8"},

--- a/push.go
+++ b/push.go
@@ -93,15 +93,20 @@ var pushCmd = cli.Command{
 
 				for _, platform := range platformList {
 					osArchArr := strings.Split(platform, "/")
-					if len(osArchArr) != 2 {
+					if len(osArchArr) != 2 && len(osArchArr) != 3 {
 						logrus.Fatal("The --platforms argument must be a string slice where one value is of the form 'os/arch'")
 					}
+					variant := ""
 					os, arch := osArchArr[0], osArchArr[1]
+					if len(osArchArr) == 3 {
+						variant = osArchArr[2]
+					}
 					srcImages = append(srcImages, types.ManifestEntry{
-						Image: strings.Replace(strings.Replace(templ, "ARCH", arch, 1), "OS", os, 1),
+						Image: strings.Replace(strings.Replace(strings.Replace(templ, "ARCH", arch, 1), "OS", os, 1), "VARIANT", variant, 1),
 						Platform: manifestlist.PlatformSpec{
 							OS:           os,
 							Architecture: arch,
+							Variant:      variant,
 						},
 					})
 				}

--- a/types/types.go
+++ b/types/types.go
@@ -20,6 +20,7 @@ type ImageInspect struct {
 	Config          *container.Config
 	Architecture    string
 	Os              string
+	Variant         string
 	OSVersion       string
 	OSFeatures      []string
 	Layers          []string

--- a/types/types.go
+++ b/types/types.go
@@ -20,7 +20,6 @@ type ImageInspect struct {
 	Config          *container.Config
 	Architecture    string
 	Os              string
-	Variant         string
 	OSVersion       string
 	OSFeatures      []string
 	Layers          []string


### PR DESCRIPTION
Adds support for `variant` for image manifest.

`arm` architectures have several different variants that are apart of the image manifest system.

Resolves Issue #71 