### PR TITLE
Add proper support for inspect of v1 image manifest

### DIFF
--- a/docker/inspect_v2.go
+++ b/docker/inspect_v2.go
@@ -193,6 +193,16 @@ func (mf *v2ManifestFetcher) pullSchema1(ctx context.Context, ref reference.Name
 		mfInfo.blobDigests = append(mfInfo.blobDigests, verifiedManifest.FSLayers[i].BlobSum)
 	}
 
+	seen := make(map[string]bool)
+	for i := 0; i < len(verifiedManifest.FSLayers); i++ {
+		digest := verifiedManifest.FSLayers[i].BlobSum.String()
+		if _, ok := seen[digest]; ok {
+			continue
+		}
+		seen[digest] = true
+		mfInfo.layers = append(mfInfo.layers, digest)
+	}
+
 	rootFS := image.NewRootFS()
 	configRaw, _ := makeRawConfigFromV1Config([]byte(verifiedManifest.History[0].V1Compatibility), rootFS, history)
 


### PR DESCRIPTION
Fixes: #74 

Fix the v1 image fetch to properly list layers for inspect.

Signed-off-by: Phil Estes <estesp@gmail.com>