### PR TITLE
Add autobuild of manifest list images

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,53 @@
----
-  language: go
-  sudo: false
-  go:
+language: go
+sudo: required
+
+services:
+    - docker
+
+go:
     - 1.10.x
     - 1.11.x
-  install:
+install:
     - go get github.com/golang/lint/golint
-  script:
+
+script:
     - make binary
     - go vet $(go list ./... | grep -v vendor)
     - test -z "$(golint ./... | grep -v vendor | tee /dev/stderr)"
     - test -z "$(gofmt -s -l . | grep -v vendor | tee /dev/stderr)"
+
+    # Make cross
+    - make cross
+    # ignore extra variants for arm; use v7 as default:
+    - cp manifest-tool-linux-armv7 manifest-tool-linux-arm
+    # Build all images
+    - docker build --build-arg PLATFORM=linux-amd64 -t mplatform/manifest-tool:linux-amd64 -f hack/Dockerfile.linux .
+    - docker build --build-arg PLATFORM=linux-arm -t mplatform/manifest-tool:linux-arm -f hack/Dockerfile.linux .
+    - docker build --build-arg PLATFORM=linux-arm64 -t mplatform/manifest-tool:linux-arm64 -f hack/Dockerfile.linux .
+    - docker build --build-arg PLATFORM=linux-ppc64le -t mplatform/manifest-tool:linux-ppc64le -f hack/Dockerfile.linux .
+    - docker build --build-arg PLATFORM=linux-s390x -t mplatform/manifest-tool:linux-s390x -f hack/Dockerfile.linux .
+
+    # Test at least Intel image
+    - docker run mplatform/manifest-tool:linux-amd64 inspect busybox:latest
+
+    - >
+      if [ -n "$TRAVIS_TAG" ]; then
+        # Push all images
+        travis_retry timeout 5m docker login -u="$DOCKER_USER" -p="$DOCKER_PASS"
+
+        docker tag mplatform/manifest-tool:linux-amd64 mplatform/manifest-tool:${TRAVIS_TAG}-linux-amd64
+        docker tag mplatform/manifest-tool:linux-arm mplatform/manifest-tool:${TRAVIS_TAG}-linux-arm
+        docker tag mplatform/manifest-tool:linux-arm64 mplatform/manifest-tool:${TRAVIS_TAG}-linux-arm64
+        docker tag mplatform/manifest-tool:linux-ppc64le mplatform/manifest-tool:${TRAVIS_TAG}-linux-ppc64le
+        docker tag mplatform/manifest-tool:linux-s390x mplatform/manifest-tool:${TRAVIS_TAG}-linux-s390x
+        # push version for each platform
+        docker push mplatform/manifest-tool:${TRAVIS_TAG}-linux-amd64
+        docker push mplatform/manifest-tool:${TRAVIS_TAG}-linux-arm
+        docker push mplatform/manifest-tool:${TRAVIS_TAG}-linux-arm64
+        docker push mplatform/manifest-tool:${TRAVIS_TAG}-linux-ppc64le
+        docker push mplatform/manifest-tool:${TRAVIS_TAG}-linux-s390x
+
+        # Push manifest-list
+        ./manifest-tool push from-args --platforms linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/s390x,windows/amd64 --template "mplatform/manifest-tool:${TRAVIS_TAG}-OS-ARCH" --target "mplatform/manifest-tool:$TRAVIS_TAG"
+        ./manifest-tool push from-args --platforms linux/amd64,linux/arm,linux/arm64,linux/ppc64le,linux/s390x,windows/amd64 --template "mplatform/manifest-tool:${TRAVIS_TAG}-OS-ARCH" --target "mplatform/manifest-tool:latest"
+      fi

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,35 @@
+version: 1.0.{build}
+image: Visual Studio 2017
+
+clone_folder: c:\gopath\src\github.com\estesp\manifest-tool
+
+environment:
+  GOPATH: C:\gopath
+  CGO_ENABLED: 1
+  matrix:
+    - GO_VERSION: 1.11
+
+before_build:
+  - choco install -y mingw --version 5.3.0
+  # Install Go
+  - rd C:\Go /s /q
+  - appveyor DownloadFile https://storage.googleapis.com/golang/go%GO_VERSION%.windows-amd64.zip
+  - 7z x go%GO_VERSION%.windows-amd64.zip -oC:\ >nul
+  - go version
+
+build_script:
+  - bash.exe -elc "export PATH=/c/tools/mingw64/bin:$PATH ; mingw32-make.exe binary"
+  - docker build -t mplatform/manifest-tool:windows-amd64 -f hack/Dockerfile.windows .
+
+test_script:
+  - docker run mplatform/manifest-tool:windows-amd64 inspect alpine:latest 
+
+deploy_script:
+  - ps: >-
+      if (Test-Path Env:\APPVEYOR_REPO_TAG_NAME) {
+
+        docker login -u="$env:DOCKER_USER" -p="$env:DOCKER_PASS"
+        docker tag mplatform/manifest-tool:windows-amd64 mplatform/manifest-tool:$($env:APPVEYOR_REPO_TAG_NAME)-windows-amd64
+        docker push mplatform/manifest-tool:$($env:APPVEYOR_REPO_TAG_NAME)-windows-amd64
+
+      }

--- a/hack/Dockerfile.linux
+++ b/hack/Dockerfile.linux
@@ -1,0 +1,11 @@
+FROM alpine:latest as certs
+
+RUN apk --update add ca-certificates
+
+FROM scratch
+
+ARG PLATFORM=linux-amd64
+COPY --from=certs /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY manifest-tool-${PLATFORM} /manifest-tool
+
+ENTRYPOINT [ "/manifest-tool" ]

--- a/hack/Dockerfile.linux-amd64
+++ b/hack/Dockerfile.linux-amd64
@@ -1,7 +1,0 @@
-FROM alpine:3.6
-
-RUN apk update && apk add ca-certificates \
-	&& update-ca-certificates
-
-COPY manifest-tool-linux-amd64 /manifest-tool
-ENTRYPOINT [ "/manifest-tool" ]

--- a/hack/Dockerfile.linux-arm
+++ b/hack/Dockerfile.linux-arm
@@ -1,7 +1,0 @@
-FROM arm32v6/alpine:3.6
-
-RUN apk update && apk add ca-certificates \
-	&& update-ca-certificates
-
-COPY manifest-tool-linux-arm /manifest-tool
-ENTRYPOINT [ "/manifest-tool" ]

--- a/hack/Dockerfile.linux-arm64
+++ b/hack/Dockerfile.linux-arm64
@@ -1,7 +1,0 @@
-FROM arm64v8/alpine:3.6
-
-RUN apk update && apk add ca-certificates \
-	&& update-ca-certificates
-
-COPY manifest-tool-linux-arm64 /manifest-tool
-ENTRYPOINT [ "/manifest-tool" ]

--- a/hack/Dockerfile.linux-ppc64le
+++ b/hack/Dockerfile.linux-ppc64le
@@ -1,7 +1,0 @@
-FROM ppc64le/alpine:3.6
-
-RUN apk update && apk add ca-certificates \
-	&& update-ca-certificates
-
-COPY manifest-tool-linux-ppc64le /manifest-tool
-ENTRYPOINT [ "/manifest-tool" ]

--- a/hack/Dockerfile.linux-s390x
+++ b/hack/Dockerfile.linux-s390x
@@ -1,7 +1,0 @@
-FROM s390x/alpine:3.6
-
-RUN apk update && apk add ca-certificates \
-	&& update-ca-certificates
-
-COPY manifest-tool-linux-s390x /manifest-tool
-ENTRYPOINT [ "/manifest-tool" ]

--- a/hack/Dockerfile.windows
+++ b/hack/Dockerfile.windows
@@ -1,0 +1,3 @@
+FROM microsoft/nanoserver
+COPY manifest-tool manifest-tool.exe
+ENTRYPOINT [ "manifest-tool.exe" ]


### PR DESCRIPTION
Adds a manifest list image of manifest-tool itself on DockerHub for
versioned pushes; located at mplatform/manifest-tool

Closes: #73 

Signed-off-by: Phil Estes <estesp@gmail.com>