### PR TITLE
Fix insecure for http-only endpoints

### DIFF
--- a/docker/createml.go
+++ b/docker/createml.go
@@ -339,17 +339,16 @@ func setupRepo(repoInfo *registry.RepositoryInfo, insecure bool) (registry.APIEn
 	logrus.Debugf("endpoints: %v", endpoints)
 	// take highest priority endpoint
 	endpoint := endpoints[0]
-	if !repoInfo.Index.Secure {
+	// if insecure, and there is an "http" endpoint, prefer that
+	if insecure {
 		for _, ep := range endpoints {
 			if ep.URL.Scheme == "http" {
 				endpoint = ep
 			}
 		}
-	}
-
-	if insecure {
 		endpoint.TLSConfig.InsecureSkipVerify = true
 	}
+
 	repoName := repoInfo.Name.Name()
 	// If endpoint does not support CanonicalName, use the Name's path instead
 	if endpoint.TrimHostname {

--- a/docker/inspect.go
+++ b/docker/inspect.go
@@ -199,7 +199,7 @@ func GetImageData(a *types.AuthInfo, name string, insecure bool) ([]types.ImageI
 			logrus.Debugf("Skipping v1 endpoint %s; manifest list requires v2", endpoint.URL)
 			continue
 		}
-		if !repoInfo.Index.Secure && endpoint.URL.Scheme == "https" {
+		if insecure && endpoint.URL.Scheme == "https" {
 			logrus.Debugf("Skipping https endpoint for insecure registry")
 			continue
 		}


### PR DESCRIPTION
Apply insecure setting to choosing endpoints.

Applies to: #14 
When you use a local registry like `docker run -p 5000:5000 registry:2` but specify the actual IP address (not localhost or 127.0.0.1), the `Index.Secure` setting for a `repoInfo` struct is actually not correct. The solution to that would be a deeper set of fixes to utilizing the `docker/docker` imports around registry config versus writing/copying into `manifest-tool`; a workaround is simply to ignore `Index.Secure` for a repo, and use the flag of our tool to override endpoint selection ordering, and pick the **http** proto endpoint.

Signed-off-by: Phil Estes <estesp@gmail.com>