### PR TITLE
Prepare v1.0.1 release

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 version: 1.0.{build}
-image: Visual Studio 2017
+image: Visual Studio 2019
 
 clone_folder: c:\gopath\src\github.com\estesp\manifest-tool
 

--- a/hack/Dockerfile.windows
+++ b/hack/Dockerfile.windows
@@ -1,3 +1,5 @@
-FROM microsoft/nanoserver
+FROM mcr.microsoft.com/windows/servercore:1809 as core
+FROM mcr.microsoft.com/windows/nanoserver:1809
+COPY --from=core /windows/system32/netapi32.dll /windows/system32/
 COPY manifest-tool manifest-tool.exe
 ENTRYPOINT [ "manifest-tool.exe" ]

--- a/main.go
+++ b/main.go
@@ -12,7 +12,7 @@ import (
 var gitCommit = ""
 
 const (
-	version = "1.0.0"
+	version = "1.0.1"
 	usage   = "inspect and push manifest list images to a registry"
 )
 


### PR DESCRIPTION
Update version; specific focus is on re-building with latest Go 1.13
release to fix a potential s390x bug ( #86 ) and apply all Golang fixes in the Go 1.13
release history from 1.13.0 -> 1.13.8

Signed-off-by: Phil Estes <estesp@gmail.com>