### PR TITLE
Drop potential tag from digested ref for manifest refs

### DIFF
--- a/docker/createml.go
+++ b/docker/createml.go
@@ -374,7 +374,7 @@ func pushReferences(httpClient *http.Client, urlBuilder *v2.URLBuilder, ref refe
 		if err != nil {
 			return fmt.Errorf("Error parsing manifest digest (%s) for referenced manifest %q: %v", manifest.Digest, manifest.Name, err)
 		}
-		targetRef, err := reference.WithDigest(ref, dgst)
+		targetRef, err := reference.WithDigest(reference.TrimNamed(ref), dgst)
 		if err != nil {
 			return fmt.Errorf("Error creating manifest digest target for referenced manifest %q: %v", manifest.Name, err)
 		}


### PR DESCRIPTION
Fix: #98 

This should solve the issue of pushing to a tag accidentally instead of the digested reference for manifest references.

Signed-off-by: Phil Estes <estesp@linux.vnet.ibm.com>