### PR TITLE
Fix config.json file locating

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -41,10 +41,6 @@ github.com/containerd/cgroups v0.0.0-20190919134610-bf292b21730f/go.mod h1:OApqh
 github.com/containerd/console v0.0.0-20180822173158-c12b1e7919c1/go.mod h1:Tj/on1eG8kiEhd0+fhSDzsPAFESxzBBvdyEgyryXffw=
 github.com/containerd/containerd v1.3.0-beta.2.0.20190828155532-0293cbd26c69/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/containerd/containerd v1.3.2/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
-github.com/containerd/containerd v1.3.7 h1:eFSOChY8TTcxvkzp8g+Ov1RL0MYww7XEeK0y+zqGpVc=
-github.com/containerd/containerd v1.3.7/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
-github.com/containerd/containerd v1.4.1 h1:pASeJT3R3YyVn+94qEPk0SnU1OQ20Jd/T+SPKy9xehY=
-github.com/containerd/containerd v1.4.1/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/containerd/containerd v1.4.3 h1:ijQT13JedHSHrQGWFcGEwzcNKrAGIiZ+jSD5QQG07SY=
 github.com/containerd/containerd v1.4.3/go.mod h1:bC6axHOhabU15QhwfG7w5PipXdVtMXFTttgp+kVtyUA=
 github.com/containerd/continuity v0.0.0-20190426062206-aaeac12a7ffc/go.mod h1:GL3xCUCBDV3CZiTSEKksMWbLE66hEyuu9qyDOOqM47Y=

--- a/pkg/registry/push.go
+++ b/pkg/registry/push.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"path/filepath"
 
 	"github.com/docker/distribution/reference"
 	"github.com/estesp/manifest-tool/pkg/store"
@@ -23,7 +22,7 @@ func PushManifestList(username, password string, input types.YAMLInput, ignoreMi
 
 	var configDirs []string
 	if configDir != "" {
-		configDirs = append(configDirs, filepath.Join(configDir, "config.json"))
+		configDirs = append(configDirs, configDir)
 	}
 	resolver := util.NewResolver(username, password, insecure,
 		plainHttp, configDirs...)


### PR DESCRIPTION
Short Issue Description

```bash
$ manifest-tool push from-spec manifest.yaml 
WARN[0000] Error loading auth file: /home/nfox/.docker/config.json/config.json: stat /home/nfox/.docker/config.json/config.json: not a directory 
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x89371c]
```

More details

`config.json` is treated as a directory that leads to a go-panic. As a workaround, it's still possible to create  ~/.docker/config.json/ directory and put there config.json => ~/.docker/config.json/config.json.

Unfortunately, I haven't found test cases so I might have fixed the wrong place, but it works well now.