### PR TITLE
Add ability to test pushing an index using only tags

### DIFF
--- a/integration/test-registry-tag.yml
+++ b/integration/test-registry-tag.yml
@@ -1,0 +1,23 @@
+image: __REGISTRY__:latest
+manifests:
+  -
+    image: __REGISTRY__:ppc64le_alpine_latest
+    platform:
+      architecture: ppc64le
+      os: linux
+  -
+    image: __REGISTRY__:amd64_alpine_latest
+    platform:
+      architecture: amd64
+      os: linux
+  -
+    image: __REGISTRY__:s390x_alpine_latest
+    platform:
+      architecture: s390x
+      os: linux
+  -
+    image: __REGISTRY__:aarch64_alpine_latest
+    platform:
+      architecture: arm64
+      os: linux
+      variant: v8


### PR DESCRIPTION
Instead of pushing different image names for the registry test, allow a
variant which only uses tags to differentiate into a single image
repository.

Signed-off-by: Phil Estes <estesp@gmail.com>