### PR TITLE
Fix push with Windows foreign layer references

### DIFF
--- a/pkg/registry/fetcher.go
+++ b/pkg/registry/fetcher.go
@@ -75,7 +75,7 @@ func nonLayerChildHandler(provider ccontent.Provider) images.HandlerFunc {
 			}
 
 			descs = append(descs, index.Manifests...)
-		case ocispec.MediaTypeImageLayer, ocispec.MediaTypeImageLayerGzip, types.MediaTypeDockerTarLayer, types.MediaTypeDockerTarGzipLayer:
+		case ocispec.MediaTypeImageLayer, ocispec.MediaTypeImageLayerGzip, types.MediaTypeDockerTarGzipLayer:
 			// we want to save the descriptor info about layers in our content store
 			// in case we are going to handle push of a manifest list (will need to handle
 			// have the details for doing blob mounting on manifest list/index push)

--- a/pkg/types/image.go
+++ b/pkg/types/image.go
@@ -9,10 +9,8 @@ const (
 	MediaTypeDockerSchema2Manifest = "application/vnd.docker.distribution.manifest.v2+json"
 	// MediaTypeDockerSchema2ManifestList is the Docker v2.2 schema media type for a manifest list object
 	MediaTypeDockerSchema2ManifestList = "application/vnd.docker.distribution.manifest.list.v2+json"
-	// MediaTypeDockerTarLayer is the Docker schema media type for a tar filesystem layer
-	MediaTypeDockerTarLayer = "application/vnd.docker.image.rootfs.diff.tar.gzip"
 	// MediaTypeDockerTarGzipLayer is the Docker schema media type for a tar+gzip filesystem layer
-	MediaTypeDockerTarGzipLayer = "application/vnd.docker.image.rootfs.foreign.diff.tar.gzip"
+	MediaTypeDockerTarGzipLayer = "application/vnd.docker.image.rootfs.diff.tar.gzip"
 )
 
 // Image struct handles Windows support extensions to OCI spec


### PR DESCRIPTION
The "2.x" manifest-tool codebase hadn't yet been tested with Windows image references that had foreign/non-distributable layers. The generic push content code being used from containerd doesn't filter on foreign layers so it required that we filter out those references before calling `PushContent` so that manifest lists with Windows image references can be pushed successfully to a registry.