### PR TITLE
Fix segfault and add (optional) variant in image config

### DIFF
--- a/pkg/registry/push.go
+++ b/pkg/registry/push.go
@@ -121,22 +121,26 @@ func resolvePlatform(descriptor ocispec.Descriptor, img types.ManifestEntry, img
 		platform = &ocispec.Platform{}
 	}
 	// fill os/arch from inspected image if not specified in input YAML
-	if img.Platform.OS == "" && img.Platform.Architecture == "" {
+	if platform.OS == "" && platform.Architecture == "" {
 		// prefer a full platform object, if one is already available (and appears to have meaningful content)
-		if descriptor.Platform.OS != "" || descriptor.Platform.Architecture != "" {
+		if descriptor.Platform != nil && (descriptor.Platform.OS != "" || descriptor.Platform.Architecture != "") {
 			platform = descriptor.Platform
 		} else if imgConfig.OS != "" || imgConfig.Architecture != "" {
 			platform.OS = imgConfig.OS
 			platform.Architecture = imgConfig.Architecture
 		}
 	}
+	// if Variant is specified in the origin image but not the descriptor or YAML, bubble it up
+	if imgConfig.Variant != "" && platform.Variant == "" {
+		platform.Variant = imgConfig.Variant
+	}
 	// Windows: if the origin image has OSFeature and/or OSVersion information, and
 	// these values were not specified in the creation YAML, then
 	// retain the origin values in the Platform definition for the manifest list:
-	if imgConfig.OSVersion != "" && img.Platform.OSVersion == "" {
+	if imgConfig.OSVersion != "" && platform.OSVersion == "" {
 		platform.OSVersion = imgConfig.OSVersion
 	}
-	if len(imgConfig.OSFeatures) > 0 && len(img.Platform.OSFeatures) == 0 {
+	if len(imgConfig.OSFeatures) > 0 && len(platform.OSFeatures) == 0 {
 		platform.OSFeatures = imgConfig.OSFeatures
 	}
 

--- a/pkg/types/image.go
+++ b/pkg/types/image.go
@@ -16,6 +16,8 @@ const (
 // Image struct handles Windows support extensions to OCI spec
 type Image struct {
 	ocispec.Image
+	// TODO https://github.com/opencontainers/image-spec/pull/809
+	Variant    string   `json:"variant,omitempty"`
 	OSVersion  string   `json:"os.version,omitempty"`
 	OSFeatures []string `json:"os.features,omitempty"`
 }


### PR DESCRIPTION
When using a YAML file that doesn't include `platform:` objects at all, the following is the result:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x8aa679]

goroutine 1 [running]:
github.com/estesp/manifest-tool/pkg/registry.resolvePlatform(0xc000568840, 0x34, 0xc000578b90, 0x47, 0x20f, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/go/src/github.com/estesp/manifest-tool/pkg/registry/push.go:126 +0xb9
github.com/estesp/manifest-tool/pkg/registry.PushManifestList(0x0, 0x0, 0x0, 0x0, 0xc00045a168, 0x15, 0x0, 0x0, 0x0, 0xc00040aa80, ...)
	/go/src/github.com/estesp/manifest-tool/pkg/registry/push.go:92 +0xdfb
main.glob..func2(0xc00044c420)
	/go/src/github.com/estesp/manifest-tool/cmd/manifest-tool/push.go:55 +0x3cf
github.com/urfave/cli.HandleAction(0x98c520, 0xa7a7b8, 0xc00044c420, 0xc00044c420, 0x0)
	/go/src/github.com/estesp/manifest-tool/vendor/github.com/urfave/cli/app.go:525 +0x59
github.com/urfave/cli.Command.Run(0xa503af, 0x9, 0x0, 0x0, 0x0, 0x0, 0x0, 0xa68e68, 0x32, 0x0, ...)
	/go/src/github.com/estesp/manifest-tool/vendor/github.com/urfave/cli/command.go:174 +0x579
github.com/urfave/cli.(*App).RunAsSubcommand(0xc000472380, 0xc00044c160, 0x0, 0x0)
	/go/src/github.com/estesp/manifest-tool/vendor/github.com/urfave/cli/app.go:404 +0x914
github.com/urfave/cli.Command.startApp(0xa4c181, 0x4, 0x0, 0x0, 0x0, 0x0, 0x0, 0xa6de45, 0x4e, 0x0, ...)
	/go/src/github.com/estesp/manifest-tool/vendor/github.com/urfave/cli/command.go:373 +0x7ff
github.com/urfave/cli.Command.Run(0xa4c181, 0x4, 0x0, 0x0, 0x0, 0x0, 0x0, 0xa6de45, 0x4e, 0x0, ...)
	/go/src/github.com/estesp/manifest-tool/vendor/github.com/urfave/cli/command.go:102 +0xa14
github.com/urfave/cli.(*App).Run(0xc0004721c0, 0xc000020080, 0x4, 0x4, 0x0, 0x0)
	/go/src/github.com/estesp/manifest-tool/vendor/github.com/urfave/cli/app.go:276 +0x7e8
main.runApplication(0xc000000180, 0xc00025ff78)
	/go/src/github.com/estesp/manifest-tool/cmd/manifest-tool/main.go:75 +0x605
main.main()
	/go/src/github.com/estesp/manifest-tool/cmd/manifest-tool/main.go:20 +0x26
```