### PR TITLE
read lock added to fix unsafe concurrent read

### DIFF
--- a/v2/pkg/store/store.go
+++ b/v2/pkg/store/store.go
@@ -18,7 +18,7 @@ var (
 )
 
 type labelStore struct {
-	l      sync.Mutex
+	l      sync.RWMutex
 	labels map[digest.Digest]map[string]string
 }
 
@@ -87,10 +87,12 @@ func (m *MemoryStore) Delete(ctx context.Context, d digest.Digest) error {
 
 // Info returns the info for a specific digest
 func (m *MemoryStore) Info(ctx context.Context, d digest.Digest) (ccontent.Info, error) {
+	m.labels.l.RLock()
 	info := ccontent.Info{
 		Digest: d,
 		Labels: m.labels.labels[d],
 	}
+	m.labels.l.Unlock()
 	return info, nil
 }
 

--- a/v2/pkg/store/store.go
+++ b/v2/pkg/store/store.go
@@ -92,7 +92,7 @@ func (m *MemoryStore) Info(ctx context.Context, d digest.Digest) (ccontent.Info,
 		Digest: d,
 		Labels: m.labels.labels[d],
 	}
-	m.labels.l.Unlock()
+	m.labels.l.RUnlock()
 	return info, nil
 }
 


### PR DESCRIPTION
We use `manifest-tool` and stumbled upon the issue with concurrent map read/write. I've added `sync.RWMutex` to fix it.

```
fatal error: concurrent map read and map write
2021-12-17T18:15:42.8029105Z 
2021-12-17T18:15:42.8029940Z goroutine 566 [running]:
2021-12-17T18:15:42.8031106Z runtime.throw({0xad8696, 0xbbc210})
2021-12-17T18:15:42.8032688Z 	/opt/hostedtoolcache/go/1.17.5/x64/src/runtime/panic.go:1198 +0x71 fp=0xc000cf7990 sp=0xc000cf7960 pc=0x435d91
2021-12-17T18:15:42.8034224Z runtime.mapaccess1_faststr(0x3, 0xc0004f3680, {0xc000cba230, 0x47})
2021-12-17T18:15:42.8036332Z 	/opt/hostedtoolcache/go/1.17.5/x64/src/runtime/map_faststr.go:21 +0x3a5 fp=0xc000cf79f8 sp=0xc000cf7990 pc=0x413f65
2021-12-17T18:15:42.8038956Z github.com/estesp/manifest-tool/v2/pkg/store.(*MemoryStore).Info(0x50, {0x1048d60, 0xc0004f3680}, {0xc000cba230, 0xc000b51c80})
2021-12-17T18:15:42.8041216Z 	/home/runner/go/pkg/mod/github.com/estesp/manifest-tool/v2@v2.0.0-beta.1/pkg/store/store.go:92 +0x90 fp=0xc000cf7a78 sp=0xc000cf79f8 pc=0x92f750
2021-12-17T18:15:42.8043194Z github.com/containerd/containerd/remotes/docker.AppendDistributionSourceLabel.func1({0xba8bf8, 0xc000d14780}, {{0xc000cb4180, 0x34}, {0xc000cba230, 0x47}, 0x20e, {0x0, 0x0, 0x0}, ...})
2021-12-17T18:15:42.8045651Z 	/home/runner/go/pkg/mod/github.com/containerd/containerd@v1.5.8/remotes/docker/handler.go:52 +0xd3 fp=0xc000cf7cb0 sp=0xc000cf7a78 pc=0x93a633
2021-12-17T18:15:42.8047451Z github.com/containerd/containerd/images.HandlerFunc.Handle(0x103300504ff0101, {0xba8bf8, 0xc000d14780}, {{0xc000cb4180, 0x34}, {0xc000cba230, 0x47}, 0x20e, {0x0, 0x0, ...}, ...})
2021-12-17T18:15:42.8050967Z 	/home/runner/go/pkg/mod/github.com/containerd/containerd@v1.5.8/images/handlers.go:55 +0x5f fp=0xc000cf7d20 sp=0xc000cf7cb0 pc=0x926abf
2021-12-17T18:15:42.8052715Z github.com/containerd/containerd/images.Handlers.func1({0xba8bf8, 0xc000d14780}, {{0xc000cb4180, 0x34}, {0xc000cba230, 0x47}, 0x20e, {0x0, 0x0, 0x0}, ...})
2021-12-17T18:15:42.8054776Z 	/home/runner/go/pkg/mod/github.com/containerd/containerd@v1.5.8/images/handlers.go:65 +0x125 fp=0xc000cf7df0 sp=0xc000cf7d20 pc=0x926cc5
2021-12-17T18:15:42.8056777Z github.com/containerd/containerd/images.HandlerFunc.Handle(0x411674dbc83e52d1, {0xba8bf8, 0xc000d14780}, {{0xc000cb4180, 0x34}, {0xc000cba230, 0x47}, 0x20e, {0x0, 0x0, ...}, ...})
2021-12-17T18:15:42.8173244Z 	/home/runner/go/pkg/mod/github.com/containerd/containerd@v1.5.8/images/handlers.go:55 +0x5f fp=0xc000cf7e60 sp=0xc000cf7df0 pc=0x926abf
2021-12-17T18:15:42.8174791Z github.com/containerd/containerd/images.Dispatch.func1()
2021-12-17T18:15:42.8185570Z 	/home/runner/go/pkg/mod/github.com/containerd/containerd@v1.5.8/images/handlers.go:134 +0xb5 fp=0xc000cf7f78 sp=0xc000cf7e60 pc=0x927215
2021-12-17T18:15:42.8186738Z golang.org/x/sync/errgroup.(*Group).Go.func1()
2021-12-17T18:15:42.8189161Z 	/home/runner/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:57 +0x67 fp=0xc000cf7fe0 sp=0xc000cf7f78 pc=0x926127
2021-12-17T18:15:42.8190248Z runtime.goexit()
2021-12-17T18:15:42.8191261Z 	/opt/hostedtoolcache/go/1.17.5/x64/src/runtime/asm_amd64.s:1581 +0x1 fp=0xc000cf7fe8 sp=0xc000cf7fe0 pc=0x4658c1
2021-12-17T18:15:42.8192209Z created by golang.org/x/sync/errgroup.(*Group).Go
2021-12-17T18:15:42.8193454Z 	/home/runner/go/pkg/mod/golang.org/x/sync@v0.0.0-20210220032951-036812b2e83c/errgroup/errgroup.go:54 +0x92
2021-12-17T18:15:42.8194159Z 
```