### PR TITLE
Workaround for body reuse/401 auth errors

### DIFF
--- a/v2/pkg/registry/push.go
+++ b/v2/pkg/registry/push.go
@@ -79,7 +79,7 @@ func PushManifestList(username, password string, input types.YAMLInput, ignoreMi
 		info, _ := memoryStore.Info(context.TODO(), descriptor.Digest)
 		for _, layer := range man.Layers {
 			// only need to handle cross-repo blob mount for distributable layer types
-			if nonDistributable(layer.MediaType) {
+			if skippable(layer.MediaType) {
 				continue
 			}
 			info.Digest = layer.Digest
@@ -151,8 +151,14 @@ func resolvePlatform(descriptor ocispec.Descriptor, img types.ManifestEntry, img
 	return platform, nil
 }
 
-func nonDistributable(mediaType string) bool {
+func skippable(mediaType string) bool {
+	// skip foreign/non-distributable layers
 	if strings.Index(mediaType, "foreign") > 0 || strings.Index(mediaType, "nondistributable") > 0 {
+		return true
+	}
+	// skip manifests (OCI or Dockerv2) as they are already handled on push references code
+	switch mediaType {
+	case ocispec.MediaTypeImageManifest, types.MediaTypeDockerSchema2Manifest:
 		return true
 	}
 	return false


### PR DESCRIPTION
Both GCR and Quay have a potentially different auth flow and hit a known
issue with "body reuse" in the push operation to a repo that is "public
pull" but "auth push". This works around it with a retry in this
specific case until containerd has a solution.

Fixes: #122 
Fixes: #156
Signed-off-by: Phil Estes <estesp@gmail.com>