### PR TITLE
Update Go to 1.17.8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [1.17.7]
+        go-version: [1.17.8]
         os: [ubuntu-18.04, macos-10.15, windows-2019]
 
     steps:
@@ -57,7 +57,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v1
         with:
-          go-version: 1.17.7
+          go-version: 1.17.8
 
       - name: Set env
         shell: bash
@@ -104,7 +104,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: '1.17.7'
+          go-version: '1.17.8'
 
       - name: Set env
         shell: bash
@@ -134,7 +134,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: '1.17.7'
+          go-version: '1.17.8'
 
       - name: Set env
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v2
         with:
-          go-version: '1.17.7'
+          go-version: '1.17.8'
 
       - name: Set env
         shell: bash
@@ -140,6 +140,11 @@ jobs:
     timeout-minutes: 30
 
     steps:
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '1.17.8'
+
       - name: Set env
         shell: bash
         run: |


### PR DESCRIPTION
Update to latest Go and add missing Go install in release action to
correct breaking code (default Go version too low in Actions)

Signed-off-by: Phil Estes <estesp@gmail.com>