### PR TITLE
Fix segv with docker-cfg flag and allow custom files

### DIFF
--- a/v2/cmd/manifest-tool/inspect.go
+++ b/v2/cmd/manifest-tool/inspect.go
@@ -3,7 +3,6 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"path/filepath"
 
 	"github.com/docker/distribution/reference"
 	"github.com/estesp/manifest-tool/v2/pkg/registry"
@@ -43,7 +42,7 @@ var inspectCmd = cli.Command{
 
 		memoryStore := store.NewMemoryStore()
 		resolver := util.NewResolver(c.GlobalString("username"), c.GlobalString("password"), c.GlobalBool("insecure"),
-			c.GlobalBool("plain-http"), filepath.Join(c.GlobalString("docker-cfg"), "config.json"))
+			c.GlobalBool("plain-http"), c.String("authconfig"))
 
 		descriptor, err := registry.FetchDescriptor(resolver, memoryStore, imageRef)
 		if err != nil {

--- a/v2/cmd/manifest-tool/push.go
+++ b/v2/cmd/manifest-tool/push.go
@@ -52,7 +52,7 @@ var pushCmd = cli.Command{
 					logrus.Fatalf(fmt.Sprintf("Can't unmarshal YAML file %q: %v", filePath, err))
 				}
 
-				digest, length, err := registry.PushManifestList(c.GlobalString("username"), c.GlobalString("password"), yamlInput, c.Bool("ignore-missing"), c.GlobalBool("insecure"), c.GlobalBool("plain-http"), filepath.Join(c.GlobalString("docker-cfg"), "config.json"))
+				digest, length, err := registry.PushManifestList(c.GlobalString("username"), c.GlobalString("password"), yamlInput, c.Bool("ignore-missing"), c.GlobalBool("insecure"), c.GlobalBool("plain-http"), c.String("authconfig"))
 				if err != nil {
 					logrus.Fatal(err)
 				}
@@ -115,7 +115,7 @@ var pushCmd = cli.Command{
 					Image:     target,
 					Manifests: srcImages,
 				}
-				digest, length, err := registry.PushManifestList(c.GlobalString("username"), c.GlobalString("password"), yamlInput, c.Bool("ignore-missing"), c.GlobalBool("insecure"), c.GlobalBool("plain-http"), filepath.Join(c.GlobalString("docker-cfg"), "config.json"))
+				digest, length, err := registry.PushManifestList(c.GlobalString("username"), c.GlobalString("password"), yamlInput, c.Bool("ignore-missing"), c.GlobalBool("insecure"), c.GlobalBool("plain-http"), c.String("authconfig"))
 				if err != nil {
 					logrus.Fatal(err)
 				}


### PR DESCRIPTION
Closes: #163 

Fixes a segmentation fault if a file was passed in to --docker-cfg
instead of a directory (which was expected). Now allows a path or a file
to be specified via the flag and updated the help text appropriately.

Signed-off-by: Phil Estes <estesp@gmail.com>