### PR TITLE
Update macos version in Actions to 12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.18.3]
-        os: [ubuntu-18.04, macos-10.15, windows-2019]
+        os: [ubuntu-18.04, macos-12, windows-2019]
 
     steps:
       - uses: actions/checkout@v2
@@ -100,7 +100,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-18.04, macos-10.15, windows-2019]
+        os: [ubuntu-18.04, macos-12, windows-2019]
 
     steps:
       - uses: actions/setup-go@v1


### PR DESCRIPTION
10.15 will be deprecated soon in GitHub Actions.

Signed-off-by: Phil Estes <estesp@gmail.com>