### PR TITLE
Ability to specify additional tags via from-args subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ an amd64 image:
 
 ```yaml
 image: myprivreg:5000/someimage:latest
+tags: ["1.0.0", "1.0", "1"]
 manifests:
   -
     image: myprivreg:5000/someimage:arm64
@@ -194,12 +195,14 @@ shown below:
 $ manifest-tool push from-args \
     --platforms linux/amd64,linux/s390x,linux/arm64 \
     --template foo/bar-ARCH:v1 \
+    --tags v1.0.0,v1.0 \
     --target foo/bar:v1
 ```
 
 Specifically:
  - `--platforms` specifies which platforms you want to push for in the form OS/ARCH,OS/ARCH,...
  - `--template` specifies the image repo:tag source for inputs by replacing the placeholders `OS`, `ARCH` and `VARIANT` with the inputs from `--platforms`.
+ - `--tags` specifies the tags to apply to the target image in addition to the `--target` tag.
  - `--target` specifies the target image repo:tag that will be the manifest list entry in the registry.
 
 When using the optional `VARIANT` placeholder, it is ignored when a `platform` does not have a variant.

--- a/v2/cmd/manifest-tool/push.go
+++ b/v2/cmd/manifest-tool/push.go
@@ -68,16 +68,23 @@ var pushCmd = cli.Command{
 			Usage: "push a manifest list to a registry via CLI arguments",
 			Flags: []cli.Flag{
 				cli.StringFlag{
-					Name:  "platforms",
-					Usage: "comma-separated list of the platforms that images should be pushed for",
+					Name:     "platforms",
+					Usage:    "comma-separated list of the platforms that images should be pushed for",
+					Required: true,
 				},
 				cli.StringFlag{
-					Name:  "template",
-					Usage: "the pattern the source images have. OS and ARCH in that pattern will be replaced with the actual values from the platforms list",
+					Name:     "template",
+					Usage:    "the pattern the source images have. OS and ARCH in that pattern will be replaced with the actual values from the platforms list",
+					Required: true,
 				},
 				cli.StringFlag{
-					Name:  "target",
-					Usage: "the name of the manifest list image that is going to be produced",
+					Name:     "target",
+					Usage:    "the name of the manifest list image that is going to be produced",
+					Required: true,
+				},
+				cli.StringFlag{
+					Name:  "tags",
+					Usage: "comma-separated list of additional tags to apply to the manifest list image",
 				},
 				cli.BoolFlag{
 					Name:  "ignore-missing",
@@ -88,13 +95,15 @@ var pushCmd = cli.Command{
 				platforms := c.String("platforms")
 				templ := c.String("template")
 				target := c.String("target")
+				tags := c.String("tags")
 				srcImages := []types.ManifestEntry{}
 
-				if len(platforms) == 0 || len(templ) == 0 || len(target) == 0 {
-					logrus.Fatalf("You must specify all three arguments --platforms, --template and --target")
-				}
-
 				platformList := strings.Split(platforms, ",")
+
+				var tagsList []string
+				if len(tags) > 0 {
+					tagsList = strings.Split(tags, ",")
+				}
 
 				for _, platform := range platformList {
 					osArchArr := strings.Split(platform, "/")
@@ -117,6 +126,7 @@ var pushCmd = cli.Command{
 				}
 				yamlInput := types.YAMLInput{
 					Image:     target,
+					Tags:      tagsList,
 					Manifests: srcImages,
 				}
 				manifestType := types.Docker


### PR DESCRIPTION
Only `from-spec` subcommand allowed specifying extra tags for manifest list, but this is not convinient to create or modify manifest YAML during CI.
This PR adds additional `--tags` argument to `from-args` subcommand to specify tags via command-line without touching/creating/modifying manifest during CI.

Also this PR includes minor refactoring to required cli args and adds an example to README.md