### PR TITLE
Add BATS-based integration framework

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,51 @@ jobs:
         working-directory: src/github.com/estesp/manifest-tool
 
   #
+  # Integration testing
+  #
+  tests:
+    name: Integration tests
+    runs-on: ubuntu-20.04
+    timeout-minutes: 10
+    needs: [project, linters]
+
+    steps:
+      - uses: actions/setup-go@v3
+        with:
+          go-version: '1.20.2'
+
+      - name: Set env
+        shell: bash
+        run: |
+          echo "GOPATH=${{ github.workspace }}" >> $GITHUB_ENV
+          echo "${{ github.workspace }}/bin" >> $GITHUB_PATH
+
+      - uses: actions/checkout@v3
+        with:
+          path: src/github.com/estesp/manifest-tool
+
+      - name: Make binary
+        run: make binary
+        working-directory: src/github.com/estesp/manifest-tool
+
+      - name: Set up bats
+        run: |
+          git clone https://github.com/bats-core/bats-core.git
+          cd bats-core
+          sudo ./install.sh /usr/local
+          # we need to have a known name (that isn't localhost) for local registry TLS
+          sudo echo "127.0.0.1 myregistry.local" | sudo tee -a /etc/hosts
+
+      - name: Run tests
+        env:
+          RUNTIME_TOOL: docker
+        run: |
+          bats integration/public-registry-tests.bats
+          bats integration/local-registry-tests.bats
+          bats integration/local-registry-tests-tls.bats
+        working-directory: src/github.com/estesp/manifest-tool
+
+  #
   # Cross-built architectures
   #
   cross:

--- a/integration/common-setup.bash
+++ b/integration/common-setup.bash
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+function _common_setup() {
+    # get the containing directory of this file
+    # use $BATS_TEST_FILENAME instead of ${BASH_SOURCE[0]} or $0,
+    # as those will point to the bats executable's location or the preprocessed file respectively
+    PROJECT_ROOT="$( cd "$( dirname "$BATS_TEST_FILENAME" )/.." >/dev/null 2>&1 && pwd )"
+
+    RUNTIME_TOOL="${RUNTIME_TOOL:-finch}"
+}
+
+function _load_test_images() {
+
+    "${RUNTIME_TOOL}" pull amd64/alpine:latest
+    "${RUNTIME_TOOL}" pull arm64v8/alpine:latest
+    "${RUNTIME_TOOL}" pull ppc64le/alpine:latest
+    "${RUNTIME_TOOL}" pull s390x/alpine:latest
+    "${RUNTIME_TOOL}" tag amd64/alpine:latest ${HOSTNM}/alpine:amd64
+    "${RUNTIME_TOOL}" tag ppc64le/alpine:latest ${HOSTNM}/alpine:ppc64le
+    "${RUNTIME_TOOL}" tag arm64v8/alpine:latest ${HOSTNM}/alpine:arm64
+    "${RUNTIME_TOOL}" tag s390x/alpine:latest ${HOSTNM}/alpine:s390x
+    "${RUNTIME_TOOL}" push ${HOSTNM}/alpine:amd64
+    "${RUNTIME_TOOL}" push ${HOSTNM}/alpine:arm64
+    "${RUNTIME_TOOL}" push ${HOSTNM}/alpine:ppc64le
+    "${RUNTIME_TOOL}" push ${HOSTNM}/alpine:s390x
+}

--- a/integration/local-registry-tests-tls.bats
+++ b/integration/local-registry-tests-tls.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats
+
+
+setup_file() {
+    load 'common-setup'
+    _common_setup
+    # create certs
+    export HOSTNM=${TEST_REGISTRY_HOST:-myregistry.local}
+    mkdir certs
+    openssl req -x509 -newkey rsa:4096 -sha256 -days 1 -nodes \
+     -keyout certs/ssc.key -out certs/ssc.crt -subj "/CN=${HOSTNM}" \
+     -addext "subjectAltName=DNS:${HOSTNM}"
+
+    # start a container registry
+    "${RUNTIME_TOOL}" run -d --name registry  \
+     -v "$(pwd)"/certs:/certs \
+     -e REGISTRY_HTTP_ADDR=0.0.0.0:443 \
+     -e REGISTRY_HTTP_TLS_CERTIFICATE=/certs/ssc.crt \
+     -e REGISTRY_HTTP_TLS_KEY=/certs/ssc.key \
+     -p 443:443 \
+     registry:2
+
+    _load_test_images
+}
+
+teardown_file() {
+    # stop our registry
+    "${RUNTIME_TOOL}" stop registry
+    "${RUNTIME_TOOL}" rm registry
+    rm -fR certs
+}
+
+@test "can run manifest-tool version" {
+    ./manifest-tool --version
+}
+
+@test "can inspect a basic image" {
+    ./manifest-tool --insecure inspect ${HOSTNM}/alpine:amd64
+}

--- a/integration/local-registry-tests.bats
+++ b/integration/local-registry-tests.bats
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+
+
+setup_file() {
+    load 'common-setup'
+    _common_setup
+
+    # start a container registry
+    "${RUNTIME_TOOL}" run -d -p 5000:5000 --name registry registry:2
+    export HOSTNM="localhost:5000"
+    _load_test_images
+}
+
+teardown_file() {
+    # stop our registry
+    "${RUNTIME_TOOL}" stop registry
+    "${RUNTIME_TOOL}" rm registry
+}
+
+@test "can run manifest-tool version" {
+    ./manifest-tool --version
+}
+
+@test "can inspect a basic image" {
+    ./manifest-tool inspect ${HOSTNM}/alpine:amd64
+}

--- a/integration/public-registry-tests.bats
+++ b/integration/public-registry-tests.bats
@@ -1,0 +1,18 @@
+#!/usr/bin/env bats
+
+setup_file() {
+    load 'common-setup'
+    _common_setup
+}
+
+@test "can inspect a DockerHub public image" {
+    ./manifest-tool inspect alpine:latest
+}
+
+@test "can inspect a K8s public registry image" {
+    ./manifest-tool inspect registry.k8s.io/pause:3.7
+}
+
+@test "can inspect a public ECR image on AWS" {
+    ./manifest-tool inspect public.ecr.aws/datadog/agent:7
+}


### PR DESCRIPTION
A long time coming, but we need tests to validate functionality on each PR/release. This is just the barebones start of a framework of tests against public registries and local registries and needs to be expanded to cover most of the inspect and
push capabilities over time.