### PR TITLE
Add credential helpers to Alpine image

### DIFF
--- a/hack/Dockerfile.alpine
+++ b/hack/Dockerfile.alpine
@@ -4,6 +4,16 @@ ARG TARGETARCH
 ARG TARGETVARIANT
 ARG BUILDPLATFORM
 RUN apk add bash git
+
+# Get GCR credential helper
+RUN go install github.com/GoogleCloudPlatform/docker-credential-gcr@latest
+
+# Get Amazon ECR credential helper
+RUN go install github.com/awslabs/amazon-ecr-credential-helper/ecr-login/cli/docker-credential-ecr-login@latest
+
+# Get ACR docker env credential helper
+RUN go install github.com/chrismellard/docker-credential-acr-env@latest
+
 RUN mkdir /manifest-tool
 WORKDIR /manifest-tool
 COPY  . /manifest-tool
@@ -12,5 +22,8 @@ RUN /manifest-tool/hack/makestatic.sh $TARGETARCH ${TARGETVARIANT#v}
 FROM alpine:3.17.0
 COPY --from=bld /manifest-tool/manifest-tool /manifest-tool
 COPY --from=bld /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
+COPY --from=bld --chown=0:0 /go/bin/docker-credential-gcr /usr/bin/docker-credential-gcr
+COPY --from=bld --chown=0:0 /go/bin/docker-credential-ecr-login /usr/bin/docker-credential-ecr-login
+COPY --from=bld --chown=0:0 /go/bin/docker-credential-acr-env /usr/bin/docker-credential-acr-env
 ENV PATH="${PATH}:/"
 ENTRYPOINT [ "/manifest-tool" ]


### PR DESCRIPTION
Add the GCR, ACR, and ECR credential helpers to the manifest-tool alpine-based image