### PR TITLE
fix(Dockerfile.alpine): gcloud auth naming and targetarch from alpine

### DIFF
--- a/hack/Dockerfile.alpine
+++ b/hack/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM --platform=$BUILDPLATFORM golang:1.21.3-alpine AS bld
+FROM --platform=$TARGETARCH golang:1.21.3-alpine AS bld
 ARG TARGETPLATFORM
 ARG TARGETARCH
 ARG TARGETVARIANT
@@ -22,7 +22,7 @@ RUN /manifest-tool/hack/makestatic.sh $TARGETARCH ${TARGETVARIANT#v}
 FROM alpine:3.17.0
 COPY --from=bld /manifest-tool/manifest-tool /manifest-tool
 COPY --from=bld /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certificates.crt
-COPY --from=bld --chown=0:0 /go/bin/docker-credential-gcr /usr/bin/docker-credential-gcr
+COPY --from=bld --chown=0:0 /go/bin/docker-credential-gcr /usr/bin/docker-credential-gcloud
 COPY --from=bld --chown=0:0 /go/bin/docker-credential-ecr-login /usr/bin/docker-credential-ecr-login
 COPY --from=bld --chown=0:0 /go/bin/docker-credential-acr-env /usr/bin/docker-credential-acr-env
 ENV PATH="${PATH}:/"


### PR DESCRIPTION
Hello, thanks for creating this tool. It's been helpful for our CI/CD processes. 

I am submitted this PR with two fixes that we found helpful. 
* Change `bld` to use `TARGETARCH` as we would want the from source arch to be same as the target. 
* Changing google auth helper to be named `/usr/bin/docker-credential-gcloud`. When using the gcloud helper command `gcloud auth configure-docker <gcr-or-gar>` the resulting docker config file is looking for `docker-credentials-gcloud`. 

Example docker config:
```
{
  "auths": {},
  "credsStore": "desktop",
  "credHelpers": {
    "asia.gcr.io": "gcloud",
    "eu.gcr.io": "gcloud",
    "gcr.io": "gcloud",
    "marketplace.gcr.io": "gcloud",
    "staging-k8s.gcr.io": "gcloud",
    "us.gcr.io": "gcloud",
  },
  "currentContext": "desktop-linux"
}
```
