### PR TITLE
Update macos and ubuntu runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.23.2]
-        os: [ubuntu-20.04, macos-12, windows-2019]
+        os: [ubuntu-22.04, macos-14, windows-2019]
 
     steps:
       - uses: actions/checkout@v4
@@ -102,7 +102,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-20.04, macos-12, windows-2019]
+        os: [ubuntu-22.04, macos-14, windows-2019]
 
     steps:
       - uses: actions/setup-go@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ name: manifest-tool Release
 jobs:
   check:
     name: Check Signed Tag
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 5
     outputs:
       stringver: ${{ steps.contentrel.outputs.stringver }}
@@ -50,7 +50,7 @@ jobs:
 
   build:
     name: Build binaries
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [check]
     timeout-minutes: 10
 
@@ -93,7 +93,7 @@ jobs:
 
   containers-lx:
     name: Build and push Linux release images
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [check]
     timeout-minutes: 30
 
@@ -187,7 +187,7 @@ jobs:
 
   container-assemble:
     name: Assemble and push multi-platform release image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [containers-lx, containers-win]
     timeout-minutes: 15
 
@@ -242,7 +242,7 @@ jobs:
 
   release:
     name: Create manifest-tool Release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
     needs: [build, check]
 


### PR DESCRIPTION
Update GitHub Actions CI runners for macOS and Ubuntu to more recent versions.

macos-12 runners are being deprecated soon