### PR TITLE
Clean up error handling/returns

### DIFF
--- a/integration/local-registry-tests.bats
+++ b/integration/local-registry-tests.bats
@@ -22,5 +22,5 @@ teardown_file() {
 }
 
 @test "can inspect a basic image" {
-    ./manifest-tool inspect ${HOSTNM}/alpine:amd64
+    ./manifest-tool --plain-http inspect ${HOSTNM}/alpine:amd64
 }


### PR DESCRIPTION
This fixes an issue where certain error paths were not actually returning error and the binary was exiting with zero (success) instead of failure.

Also removed all `logrus.Fatal()` and moved them to returns of `fmt.Errorf()` and use `%w` for wrapping.

Fixes: #279 