### PR TITLE
Add support for adding annotations to OCI indexes

### DIFF
--- a/integration/test-registry.yml
+++ b/integration/test-registry.yml
@@ -1,4 +1,10 @@
 image: __REGISTRY__/alpine:latest
+annotations:
+  org.opencontainers.image.title: My Image Title
+  org.opencontainers.image.description: My image description.
+  org.opencontainers.image.authors: Fred Flintstone
+  org.opencontainers.image.source: https://github.com/estesp/manifest-tool
+  org.opencontainers.image.licenses: Apache-2.0
 manifests: 
   - 
     image: __REGISTRY__/ppc64le_alpine:latest

--- a/v2/cmd/manifest-tool/push.go
+++ b/v2/cmd/manifest-tool/push.go
@@ -93,6 +93,10 @@ var pushCmd = &cli.Command{
 					Name:  "tags",
 					Usage: "comma-separated list of additional tags to apply to the manifest list image",
 				},
+				&cli.StringSliceFlag{
+					Name:  "annotations",
+					Usage: "additional image annotations to apply to the OCI index, in the form of key=value",
+				},
 				&cli.BoolFlag{
 					Name:  "ignore-missing",
 					Usage: "only warn on missing images defined in platform list",
@@ -103,6 +107,7 @@ var pushCmd = &cli.Command{
 				templ := c.String("template")
 				target := c.String("target")
 				tags := c.StringSlice("tags")
+				annotations := c.StringSlice("annotations")
 				srcImages := []types.ManifestEntry{}
 
 				for _, platform := range platforms {
@@ -124,10 +129,19 @@ var pushCmd = &cli.Command{
 						},
 					})
 				}
+				annotationMap := make(map[string]string)
+				for _, annotate := range annotations {
+					parts := strings.Split(annotate, "=")
+					if len(parts) != 2 {
+						return fmt.Errorf("the --annotations argument must be a string in the form 'key=value': %s", annotate)
+					}
+					annotationMap[parts[0]] = parts[1]
+				}
 				yamlInput := types.YAMLInput{
-					Image:     target,
-					Tags:      tags,
-					Manifests: srcImages,
+					Image:       target,
+					Tags:        tags,
+					Manifests:   srcImages,
+					Annotations: annotationMap,
 				}
 				manifestType := types.Docker
 				if c.String("type") == "oci" {

--- a/v2/pkg/types/input.go
+++ b/v2/pkg/types/input.go
@@ -5,9 +5,10 @@ import ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 // YAMLInput contains the parsed yaml fields from the push
 // command of manifest-tool
 type YAMLInput struct {
-	Image     string
-	Tags      []string
-	Manifests []ManifestEntry
+	Image       string
+	Tags        []string
+	Manifests   []ManifestEntry
+	Annotations map[string]string
 }
 
 // ManifestEntry contains an image reference and it's corresponding OCI

--- a/v2/pkg/types/manifests.go
+++ b/v2/pkg/types/manifests.go
@@ -22,11 +22,12 @@ const (
 // push the right data to a registry to form a manifestlist or OCI index
 // entry.
 type ManifestList struct {
-	Name      string
-	Type      ManifestType
-	Reference reference.Named
-	Resolver  remotes.Resolver
-	Manifests []Manifest
+	Name        string
+	Type        ManifestType
+	Reference   reference.Named
+	Resolver    remotes.Resolver
+	Manifests   []Manifest
+	Annotations map[string]string
 }
 
 // Manifest is an ocispec.Descriptor of media type manifest (OCI or Docker)


### PR DESCRIPTION
Fixes: #282 
Closes: #263 

OCI indexes support annotations and many tools/registries recommend and use the standard OCI org annotations to improve metadata visibility of images. With these changes manifest-tool will properly push annotations either as command line options or included in the YAML (the example YAML in the repo is updated to show this as well).

Since the official Docker v2 manifestList schema does not support annotations at the manifestList level (only on the manifests themselves) this tool will error out if you try and submit annotations but don't use the "--type oci" flag on the command line.