### PR TITLE
Update Windows runners based on GHActions deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       matrix:
         go-version: [1.24.2]
-        os: [ubuntu-22.04, macos-14, windows-2019]
+        os: [ubuntu-22.04, macos-14, windows-2022]
 
     steps:
       - uses: actions/checkout@v4
@@ -102,7 +102,7 @@ jobs:
 
     strategy:
       matrix:
-        os: [ubuntu-22.04, macos-14, windows-2019]
+        os: [ubuntu-22.04, macos-14, windows-2022]
 
     steps:
       - uses: actions/setup-go@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,7 +143,7 @@ jobs:
 
   containers-win:
     name: Build and push Windows release images
-    runs-on: windows-2019
+    runs-on: windows-2022
     needs: [check]
     timeout-minutes: 30
 


### PR DESCRIPTION
The windows-2019 runners are in active deprecation; moving CI and release workflows to windows-2022.