### PR TITLE
Avoid nil-pointer panic in inspect when a manifest entry has no platform

### DIFF
--- a/v2/cmd/manifest-tool/inspect.go
+++ b/v2/cmd/manifest-tool/inspect.go
@@ -133,16 +133,22 @@ func outputList(name string, cs *store.MemoryStore, descriptor ocispec.Descripto
 				continue
 			}
 			outputStr.WriteString(fmt.Sprintf("[%d] Platform:\n", i+1))
-			outputStr.WriteString(fmt.Sprintf("[%d]    -      OS: %s\n", i+1, green(img.Platform.OS)))
-			if img.Platform.OSVersion != "" {
-				outputStr.WriteString(fmt.Sprintf("[%d]    - OS Vers: %s\n", i+1, green(img.Platform.OSVersion)))
-			}
-			if len(img.Platform.OSFeatures) > 0 {
-				outputStr.WriteString(fmt.Sprintf("[%d]    - OS Feat: %s\n", i+1, green(img.Platform.OSFeatures)))
-			}
-			outputStr.WriteString(fmt.Sprintf("[%d]    -    Arch: %s\n", i+1, green(img.Platform.Architecture)))
-			if img.Platform.Variant != "" {
-				outputStr.WriteString(fmt.Sprintf("[%d]    - Variant: %s\n", i+1, green(img.Platform.Variant)))
+			// Descriptor.Platform is optional in the OCI image-spec, so an index
+			// entry may legitimately omit it. Guard the dereference to avoid a panic.
+			if img.Platform != nil {
+				outputStr.WriteString(fmt.Sprintf("[%d]    -      OS: %s\n", i+1, green(img.Platform.OS)))
+				if img.Platform.OSVersion != "" {
+					outputStr.WriteString(fmt.Sprintf("[%d]    - OS Vers: %s\n", i+1, green(img.Platform.OSVersion)))
+				}
+				if len(img.Platform.OSFeatures) > 0 {
+					outputStr.WriteString(fmt.Sprintf("[%d]    - OS Feat: %s\n", i+1, green(img.Platform.OSFeatures)))
+				}
+				outputStr.WriteString(fmt.Sprintf("[%d]    -    Arch: %s\n", i+1, green(img.Platform.Architecture)))
+				if img.Platform.Variant != "" {
+					outputStr.WriteString(fmt.Sprintf("[%d]    - Variant: %s\n", i+1, green(img.Platform.Variant)))
+				}
+			} else {
+				outputStr.WriteString(fmt.Sprintf("[%d]    -      (no platform specified)\n", i+1))
 			}
 			outputStr.WriteString(fmt.Sprintf("[%d] # Layers: %s\n", i+1, red(len(man.Layers))))
 			for j, layer := range man.Layers {

--- a/v2/cmd/manifest-tool/inspect_test.go
+++ b/v2/cmd/manifest-tool/inspect_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/estesp/manifest-tool/v2/pkg/store"
+
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+)
+
+// An OCI index entry may legitimately omit the optional "platform" field
+// (Descriptor.Platform is a *Platform with omitempty). outputList used to
+// dereference img.Platform.OS unconditionally, so such an entry panicked with
+// a nil-pointer dereference. This drives outputList with a platform-less entry
+// and asserts it renders without panicking.
+func TestOutputListNilPlatform(t *testing.T) {
+	cs := store.NewMemoryStore()
+
+	// Minimal, valid image manifest so json.Unmarshal in outputList succeeds
+	// and the store's content-addressable push accepts it.
+	man := ocispec.Manifest{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Config: ocispec.Descriptor{
+			MediaType: ocispec.MediaTypeImageConfig,
+		},
+		Layers: []ocispec.Descriptor{},
+	}
+	man.SchemaVersion = 2
+	manBytes, err := json.Marshal(man)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+
+	child := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Digest:    digest.FromBytes(manBytes),
+		Size:      int64(len(manBytes)),
+		Platform:  nil, // the platform-less entry that used to panic
+	}
+	cs.Set(child, manBytes)
+
+	index := ocispec.Index{
+		Manifests: []ocispec.Descriptor{child},
+	}
+	idxDesc := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageIndex,
+	}
+
+	// Would panic before the nil guard was added.
+	outputList("example.com/img@"+child.Digest.String(), cs, idxDesc, index)
+}
+
+// A regular entry that does carry platform data still renders its OS/arch.
+func TestOutputListWithPlatform(t *testing.T) {
+	cs := store.NewMemoryStore()
+
+	man := ocispec.Manifest{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Config:    ocispec.Descriptor{MediaType: ocispec.MediaTypeImageConfig},
+		Layers:    []ocispec.Descriptor{},
+	}
+	man.SchemaVersion = 2
+	manBytes, err := json.Marshal(man)
+	if err != nil {
+		t.Fatalf("marshal manifest: %v", err)
+	}
+
+	child := ocispec.Descriptor{
+		MediaType: ocispec.MediaTypeImageManifest,
+		Digest:    digest.FromBytes(manBytes),
+		Size:      int64(len(manBytes)),
+		Platform: &ocispec.Platform{
+			OS:           "linux",
+			Architecture: "amd64",
+		},
+	}
+	cs.Set(child, manBytes)
+
+	index := ocispec.Index{Manifests: []ocispec.Descriptor{child}}
+	idxDesc := ocispec.Descriptor{MediaType: ocispec.MediaTypeImageIndex}
+
+	// Just make sure the populated path is still reachable without panic.
+	if !strings.Contains(child.Platform.OS, "linux") {
+		t.Fatal("unexpected platform setup")
+	}
+	outputList("example.com/img", cs, idxDesc, index)
+}


### PR DESCRIPTION
Hi, I work on supply-chain security and was reading through the OCI handling in manifest-tool.

In `outputList` (v2/cmd/manifest-tool/inspect.go), the platform block dereferences `img.Platform.OS` directly for every image-manifest entry of an index. The problem is that `Descriptor.Platform` is optional in the image-spec (it's a `*Platform` with `omitempty`), so an index entry can legitimately leave the platform object out. When that happens, `img.Platform` is nil and `manifest-tool inspect <ref>` panics with a nil-pointer dereference instead of printing the entry.

The entry is reachable from a normal inspect: the fetch handler walks `index.Manifests` and stores each child manifest in the memory store, so the manifest unmarshals fine and execution reaches the platform lines. A registry that serves an index whose image-manifest entry omits `platform` is enough to crash the client.

The fix wraps the platform fields in an `if img.Platform != nil` guard and prints a short "(no platform specified)" placeholder otherwise, so the rest of the entry (layers, digest, etc.) still renders.

I added a test in package main that drives `outputList` with a platform-less entry (this panics without the guard) and a second one with a populated platform to confirm the normal path is unchanged. `go test ./v2/...` passes with the change and panics without it.

Thanks for taking a look.